### PR TITLE
Update to Prometheus.Client 4.3.0

### DIFF
--- a/examples/MetricsExample/DifferentNamespace/ServiceInDifferentNamespace.cs
+++ b/examples/MetricsExample/DifferentNamespace/ServiceInDifferentNamespace.cs
@@ -1,5 +1,5 @@
 using Motor.Extensions.Diagnostics.Metrics.Abstractions;
-using Prometheus.Client.Abstractions;
+using Prometheus.Client;
 
 namespace MetricsExample.DifferentNamespace
 {

--- a/examples/MetricsExample/ServiceWithMetrics.cs
+++ b/examples/MetricsExample/ServiceWithMetrics.cs
@@ -4,7 +4,7 @@ using MetricsExample.DifferentNamespace;
 using MetricsExample.Model;
 using Motor.Extensions.Diagnostics.Metrics.Abstractions;
 using Motor.Extensions.Hosting.Abstractions;
-using Prometheus.Client.Abstractions;
+using Prometheus.Client;
 
 namespace MetricsExample
 {

--- a/shared.csproj
+++ b/shared.csproj
@@ -1,7 +1,7 @@
 <Project>
 
     <PropertyGroup>
-        <Version>0.5.4</Version>
+        <Version>0.6.0</Version>
         <LangVersion>9</LangVersion>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>CS8600;CS8602;CS8625;CS8618;CS8604;CS8601</WarningsAsErrors>

--- a/src/Motor.Extensions.Diagnostics.Metrics.Abstractions/IMetricsFactory.cs
+++ b/src/Motor.Extensions.Diagnostics.Metrics.Abstractions/IMetricsFactory.cs
@@ -1,5 +1,5 @@
 using System.Collections.Generic;
-using Prometheus.Client.Abstractions;
+using Prometheus.Client;
 
 namespace Motor.Extensions.Diagnostics.Metrics.Abstractions
 {

--- a/src/Motor.Extensions.Diagnostics.Metrics.Abstractions/Motor.Extensions.Diagnostics.Metrics.Abstractions.csproj
+++ b/src/Motor.Extensions.Diagnostics.Metrics.Abstractions/Motor.Extensions.Diagnostics.Metrics.Abstractions.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Prometheus.Client" Version="4.2.0" />
+        <PackageReference Include="Prometheus.Client" Version="4.3.0" />
     </ItemGroup>
 
     <Import Project="$(MSBuildThisFileDirectory)../../shared.csproj" />

--- a/src/Motor.Extensions.Diagnostics.Metrics/MetricsFactory.cs
+++ b/src/Motor.Extensions.Diagnostics.Metrics/MetricsFactory.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Motor.Extensions.Diagnostics.Metrics.Abstractions;
 using Prometheus.Client;
-using Prometheus.Client.Abstractions;
 
 namespace Motor.Extensions.Diagnostics.Metrics
 {

--- a/src/Motor.Extensions.Diagnostics.Metrics/Motor.Extensions.Diagnostics.Metrics.csproj
+++ b/src/Motor.Extensions.Diagnostics.Metrics/Motor.Extensions.Diagnostics.Metrics.csproj
@@ -9,8 +9,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Prometheus.Client" Version="4.2.0" />
-        <PackageReference Include="Prometheus.Client.AspNetCore" Version="4.1.1" />
+        <PackageReference Include="Prometheus.Client" Version="4.3.0" />
+        <PackageReference Include="Prometheus.Client.AspNetCore" Version="4.2.0" />
         <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="5.0.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />

--- a/src/Motor.Extensions.Diagnostics.Metrics/PrometheusDelegatingMessageHandler.cs
+++ b/src/Motor.Extensions.Diagnostics.Metrics/PrometheusDelegatingMessageHandler.cs
@@ -2,7 +2,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Motor.Extensions.Diagnostics.Metrics.Abstractions;
 using Motor.Extensions.Hosting.Abstractions;
-using Prometheus.Client.Abstractions;
+using Prometheus.Client;
 
 namespace Motor.Extensions.Diagnostics.Metrics
 {

--- a/src/Motor.Extensions.Hosting.Kafka/KafkaMessageConsumer.cs
+++ b/src/Motor.Extensions.Hosting.Kafka/KafkaMessageConsumer.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Motor.Extensions.Diagnostics.Metrics.Abstractions;
 using Motor.Extensions.Hosting.Abstractions;
-using Prometheus.Client.Abstractions;
+using Prometheus.Client;
 
 namespace Motor.Extensions.Hosting.Kafka
 {

--- a/src/Motor.Extensions.Hosting.Publisher/TypedMessagePublisher.cs
+++ b/src/Motor.Extensions.Hosting.Publisher/TypedMessagePublisher.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Motor.Extensions.Conversion.Abstractions;
 using Motor.Extensions.Diagnostics.Metrics.Abstractions;
 using Motor.Extensions.Hosting.Abstractions;
-using Prometheus.Client.Abstractions;
+using Prometheus.Client;
 
 namespace Motor.Extensions.Hosting.Publisher
 {

--- a/src/Motor.Extensions.Hosting/Internal/BackgroundTaskQueue.cs
+++ b/src/Motor.Extensions.Hosting/Internal/BackgroundTaskQueue.cs
@@ -4,7 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Motor.Extensions.Diagnostics.Metrics.Abstractions;
 using Motor.Extensions.Hosting.Abstractions;
-using Prometheus.Client.Abstractions;
+using Prometheus.Client;
 
 namespace Motor.Extensions.Hosting.Internal
 {

--- a/src/Motor.Extensions.Hosting/MultiOutputServiceAdapter.cs
+++ b/src/Motor.Extensions.Hosting/MultiOutputServiceAdapter.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Motor.Extensions.Diagnostics.Metrics.Abstractions;
 using Motor.Extensions.Hosting.Abstractions;
-using Prometheus.Client.Abstractions;
+using Prometheus.Client;
 
 namespace Motor.Extensions.Hosting
 {

--- a/src/Motor.Extensions.Http/PrometheusDelegatingHandler.cs
+++ b/src/Motor.Extensions.Http/PrometheusDelegatingHandler.cs
@@ -3,7 +3,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Motor.Extensions.Diagnostics.Metrics.Abstractions;
-using Prometheus.Client.Abstractions;
+using Prometheus.Client;
 
 namespace Motor.Extensions.Http
 {

--- a/test/Motor.Extensions.Hosting_IntegrationTest/GenericHostingTests.cs
+++ b/test/Motor.Extensions.Hosting_IntegrationTest/GenericHostingTests.cs
@@ -26,7 +26,7 @@ using Motor.Extensions.Hosting.RabbitMQ_IntegrationTest;
 using Motor.Extensions.Hosting.RabbitMQ.Options;
 using Motor.Extensions.TestUtilities;
 using Motor.Extensions.Utilities;
-using Prometheus.Client.Abstractions;
+using Prometheus.Client;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using RandomDataGenerator.FieldOptions;

--- a/test/Motor.Extensions.Utilities_IntegrationTest/DemonstrationTests.cs
+++ b/test/Motor.Extensions.Utilities_IntegrationTest/DemonstrationTests.cs
@@ -13,7 +13,7 @@ using Motor.Extensions.Hosting.Publisher;
 using Motor.Extensions.Hosting.RabbitMQ;
 using Motor.Extensions.Hosting.RabbitMQ_IntegrationTest;
 using Motor.Extensions.Utilities;
-using Prometheus.Client.Abstractions;
+using Prometheus.Client;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using Xunit;


### PR DESCRIPTION
This is a breaking change because all metric related interfaces (IMetricFamily, ICounter, ...) were moved from Prometheus.Client.Abstractions to Prometheus.Client.