### PR TITLE
Add health check for too many temporary failures

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,7 @@ indent_style = space
 end_of_line = lf
 charset = utf-8
 insert_final_newline = true
+max_line_length = 120
 
 [*.xml]
 indent_size = 4

--- a/Motor.NET.sln
+++ b/Motor.NET.sln
@@ -12,6 +12,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitignore = .gitignore
 		Readme.md = Readme.md
 		shared.csproj = shared.csproj
+		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Motor.Extensions.Hosting.RabbitMQ", "src\Motor.Extensions.Hosting.RabbitMQ\Motor.Extensions.Hosting.RabbitMQ.csproj", "{29797CA7-CF31-4A11-B2DF-FB5F5525493E}"

--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,9 @@
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/f74a6fde2c2d490bb60f42590d554e1c)](https://www.codacy.com/gh/GDATASoftwareAG/motornet/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=GDATASoftwareAG/motornet&amp;utm_campaign=Badge_Grade)
 
 ## About Motor.NET
-Motor.NET is a micro-service framework for .NET built on top of [Microsoft Generic Hosting](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/generic-host?view=aspnetcore-3.1). It provides easy integration of RabbitMQ, Kafka (WIP) and HTTP as well as helpers for logging and tracing.
+
+Motor.NET is a micro-service framework for .NET built on top of [Microsoft Generic Hosting](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/generic-host?view=aspnetcore-3.1).
+It provides easy integration of RabbitMQ, Kafka (WIP) and HTTP as well as helpers for logging and tracing.
 
 You should be up and running with just a few lines of code.
 
@@ -29,6 +31,13 @@ You find working examples for different use-cases under the [examples](./example
 | Http | (:heavy_check_mark:) | (:heavy_check_mark:) | :x: |:heavy_check_mark:| |
 | Timer | (:heavy_check_mark:) | - | :x: | :x:| |
 | SQS | (:heavy_check_mark:) | - | :x: | :x:| |
+
+## Health Checks
+
+Motor.NET comes by default already with two health checks for message processing services (RabbitMQ, Kafka, Timer, and SQS):
+
+- `MessageProcessingHealthCheck`: Fails when no messages were consumed in a certain time frame from the Motor.NET internal queue although it has at least some messages.
+- `TooManyTemporaryFailuresHealthCheck`: Fails when too many messages led to a failure since the last message was correctly handled (either successful or as invalid input).
 
 ## License
 

--- a/shared.csproj
+++ b/shared.csproj
@@ -1,7 +1,7 @@
 <Project>
 
     <PropertyGroup>
-        <Version>0.6.3</Version>
+        <Version>0.6.4</Version>
         <LangVersion>9</LangVersion>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>CS8600;CS8602;CS8625;CS8618;CS8604;CS8601</WarningsAsErrors>

--- a/src/Motor.Extensions.Hosting/HealthChecks/MessageProcessingHealthCheck.cs
+++ b/src/Motor.Extensions.Hosting/HealthChecks/MessageProcessingHealthCheck.cs
@@ -12,7 +12,7 @@ namespace Motor.Extensions.Hosting.HealthChecks
         private readonly TimeSpan _maxTimeWithoutAcknowledgedMessage;
         private readonly IBackgroundTaskQueue<MotorCloudEvent<TInput>> _queue;
 
-        public MessageProcessingHealthCheck(IOptions<MessageProcessingHealthCheckOptions> options,
+        public MessageProcessingHealthCheck(IOptions<MessageProcessingOptions> options,
             IBackgroundTaskQueue<MotorCloudEvent<TInput>> queue)
         {
             _maxTimeWithoutAcknowledgedMessage = options.Value.MaxTimeSinceLastProcessedMessage;

--- a/src/Motor.Extensions.Hosting/HealthChecks/MessageProcessingOptions.cs
+++ b/src/Motor.Extensions.Hosting/HealthChecks/MessageProcessingOptions.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Motor.Extensions.Hosting.HealthChecks
 {
-    public record MessageProcessingHealthCheckOptions
+    public record MessageProcessingOptions
     {
         public TimeSpan MaxTimeSinceLastProcessedMessage { get; set; } = TimeSpan.FromMinutes(5);
     }

--- a/src/Motor.Extensions.Hosting/HealthChecks/TooManyTemporaryFailuresDelegatingMessageHandler.cs
+++ b/src/Motor.Extensions.Hosting/HealthChecks/TooManyTemporaryFailuresDelegatingMessageHandler.cs
@@ -1,0 +1,26 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Motor.Extensions.Hosting.Abstractions;
+
+namespace Motor.Extensions.Hosting.HealthChecks
+{
+    public class TooManyTemporaryFailuresDelegatingMessageHandler<TInput> : DelegatingMessageHandler<TInput>
+        where TInput : class
+    {
+        private readonly TooManyTemporaryFailuresStatistics<TInput> _statistics;
+
+        public TooManyTemporaryFailuresDelegatingMessageHandler(
+            TooManyTemporaryFailuresStatistics<TInput> statistics)
+        {
+            _statistics = statistics;
+        }
+
+        public override async Task<ProcessedMessageStatus> HandleMessageAsync(MotorCloudEvent<TInput> dataCloudEvent,
+            CancellationToken token = default)
+        {
+            var processedMessageStatus = await base.HandleMessageAsync(dataCloudEvent, token).ConfigureAwait(false);
+            await _statistics.RegisterMessageStatusAsync(processedMessageStatus).ConfigureAwait(false);
+            return processedMessageStatus;
+        }
+    }
+}

--- a/src/Motor.Extensions.Hosting/HealthChecks/TooManyTemporaryFailuresHealthCheck.cs
+++ b/src/Motor.Extensions.Hosting/HealthChecks/TooManyTemporaryFailuresHealthCheck.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+
+namespace Motor.Extensions.Hosting.HealthChecks
+{
+    public class TooManyTemporaryFailuresHealthCheck<TInput> : IHealthCheck where TInput : class
+    {
+        private readonly TooManyTemporaryFailuresStatistics<TInput> _statistics;
+        private readonly TooManyTemporaryFailuresOptions _options;
+
+        public TooManyTemporaryFailuresHealthCheck(IOptions<TooManyTemporaryFailuresOptions> options,
+            TooManyTemporaryFailuresStatistics<TInput> statistics)
+        {
+            _statistics = statistics;
+            _options = options.Value;
+        }
+
+        public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context,
+            CancellationToken cancellationToken = default)
+        {
+            if (_statistics.TemporaryFailureCountSinceLastHandledMessage >
+                _options.MaxTemporaryFailuresSinceLastHandledMessage && _statistics.LastHandledMessageAt <
+                DateTimeOffset.UtcNow - _options.MaxTimeSinceLastHandledMessage)
+            {
+                return Task.FromResult(HealthCheckResult.Unhealthy());
+            }
+            return Task.FromResult(HealthCheckResult.Healthy());
+        }
+    }
+}

--- a/src/Motor.Extensions.Hosting/HealthChecks/TooManyTemporaryFailuresOptions.cs
+++ b/src/Motor.Extensions.Hosting/HealthChecks/TooManyTemporaryFailuresOptions.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Motor.Extensions.Hosting.HealthChecks
+{
+    public record TooManyTemporaryFailuresOptions
+    {
+        /// <summary>
+        /// Gets or sets the maximum number of temporary failures since the last message was handled for the health check
+        /// to succeed. (Default: 1000)
+        /// </summary>
+        public uint MaxTemporaryFailuresSinceLastHandledMessage { get; set; } = 1000;
+
+        /// <summary>
+        /// Gets or sets the timespan since when the last message needs to be successfully handled for the health check
+        /// to succeed. (Default: 30s)
+        /// </summary>
+        public TimeSpan MaxTimeSinceLastHandledMessage { get; set; } = TimeSpan.FromSeconds(30);
+    }
+}

--- a/src/Motor.Extensions.Hosting/HealthChecks/TooManyTemporaryFailuresStatistics.cs
+++ b/src/Motor.Extensions.Hosting/HealthChecks/TooManyTemporaryFailuresStatistics.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Motor.Extensions.Hosting.Abstractions;
+
+namespace Motor.Extensions.Hosting.HealthChecks
+{
+    // ReSharper disable once UnusedTypeParameter
+    public class TooManyTemporaryFailuresStatistics<TInput>
+    {
+        public DateTimeOffset LastHandledMessageAt { get; set; } = DateTimeOffset.MinValue;
+        public uint TemporaryFailureCountSinceLastHandledMessage { get; set; }
+
+        private readonly SemaphoreSlim _semaphore = new(1, 1);
+
+        public async Task RegisterMessageStatusAsync(ProcessedMessageStatus lastStatus)
+        {
+            await _semaphore.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                switch (lastStatus)
+                {
+                    case ProcessedMessageStatus.Success:
+                    case ProcessedMessageStatus.InvalidInput:
+                        LastHandledMessageAt = DateTimeOffset.UtcNow;
+                        TemporaryFailureCountSinceLastHandledMessage = 0;
+                        break;
+                    case ProcessedMessageStatus.CriticalFailure:
+                    case ProcessedMessageStatus.TemporaryFailure:
+                        TemporaryFailureCountSinceLastHandledMessage++;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(lastStatus), lastStatus, null);
+                }
+            }
+            finally
+            {
+                _semaphore.Release();
+            }
+        }
+    }
+}

--- a/test/Motor.Extensions.Hosting_UnitTest/HealthChecks/MessageProcessingHealthCheckTest.cs
+++ b/test/Motor.Extensions.Hosting_UnitTest/HealthChecks/MessageProcessingHealthCheckTest.cs
@@ -6,7 +6,7 @@ using Motor.Extensions.Hosting.Abstractions;
 using Motor.Extensions.Hosting.HealthChecks;
 using Xunit;
 
-namespace Motor.Extensions.Hosting_UnitTest
+namespace Motor.Extensions.Hosting_UnitTest.HealthChecks
 {
     public class MessageProcessingHealthCheckTest
     {
@@ -54,7 +54,7 @@ namespace Motor.Extensions.Hosting_UnitTest
             int itemCount)
         {
             var maxTimeSinceLastProcessedMessage = TimeSpan.FromMilliseconds(100);
-            var config = new MessageProcessingHealthCheckOptions
+            var config = new MessageProcessingOptions
             {
                 MaxTimeSinceLastProcessedMessage = maxTimeSinceLastProcessedMessage
             };
@@ -64,7 +64,7 @@ namespace Motor.Extensions.Hosting_UnitTest
                 : DateTimeOffset.UtcNow.Subtract(maxTimeSinceLastProcessedMessage - TimeSpan.FromMilliseconds(50)));
             queue.Setup(q => q.ItemCount).Returns(itemCount);
             return new MessageProcessingHealthCheck<string>(
-                new OptionsWrapper<MessageProcessingHealthCheckOptions>(config),
+                new OptionsWrapper<MessageProcessingOptions>(config),
                 queue.Object);
         }
     }

--- a/test/Motor.Extensions.Hosting_UnitTest/HealthChecks/TooManyTemporaryFailuresHealthCheckTest.cs
+++ b/test/Motor.Extensions.Hosting_UnitTest/HealthChecks/TooManyTemporaryFailuresHealthCheckTest.cs
@@ -1,0 +1,89 @@
+using System;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using Motor.Extensions.Hosting.HealthChecks;
+using Xunit;
+
+namespace Motor.Extensions.Hosting_UnitTest.HealthChecks
+{
+    public class TooManyTemporaryFailuresHealthCheckTest
+    {
+        [Fact]
+        public async void CheckHealthAsync_NoTemporaryFailure_ServiceHealthy()
+        {
+            var healthCheck = CreateHealthCheck(new TooManyTemporaryFailuresStatistics<string>
+            {
+                LastHandledMessageAt = DateTimeOffset.UtcNow,
+                TemporaryFailureCountSinceLastHandledMessage = 0
+            });
+
+            var result = (await healthCheck.CheckHealthAsync(new HealthCheckContext())).Status;
+
+            Assert.Equal(HealthStatus.Healthy, result);
+        }
+
+        [Fact]
+        public async void CheckHealthAsync_ManyTemporaryFailuresAfterLastHandledMessage_ServiceIsUnhealthy()
+        {
+            var healthCheck = CreateHealthCheck(new TooManyTemporaryFailuresStatistics<string>
+            {
+                LastHandledMessageAt = DateTimeOffset.MinValue,
+                TemporaryFailureCountSinceLastHandledMessage = 1001
+            });
+
+            var result = (await healthCheck.CheckHealthAsync(new HealthCheckContext())).Status;
+
+            Assert.Equal(HealthStatus.Unhealthy, result);
+        }
+
+        [Fact]
+        public async void CheckHealthAsync_SingleTemporaryFailureAfterRecentLastHandledMessage_ServiceIsHealthy()
+        {
+            var healthCheck = CreateHealthCheck(new TooManyTemporaryFailuresStatistics<string>
+            {
+                LastHandledMessageAt = DateTimeOffset.UtcNow,
+                TemporaryFailureCountSinceLastHandledMessage = 1
+            });
+
+            var result = (await healthCheck.CheckHealthAsync(new HealthCheckContext())).Status;
+
+            Assert.Equal(HealthStatus.Healthy, result);
+        }
+
+        [Fact]
+        public async void CheckHealthAsync_SingleTemporaryFailureAfterLastHandledMessage_ServiceIsHealthy()
+        {
+            var healthCheck = CreateHealthCheck(new TooManyTemporaryFailuresStatistics<string>
+            {
+                LastHandledMessageAt = DateTimeOffset.MinValue,
+                TemporaryFailureCountSinceLastHandledMessage = 1
+            });
+
+            var result = (await healthCheck.CheckHealthAsync(new HealthCheckContext())).Status;
+
+            Assert.Equal(HealthStatus.Healthy, result);
+        }
+
+        [Fact]
+        public async void CheckHealthAsync_ManyTemporaryFailureAfterRecentLastHandledMessage_ServiceIsHealthy()
+        {
+            var healthCheck = CreateHealthCheck(new TooManyTemporaryFailuresStatistics<string>
+            {
+                LastHandledMessageAt = DateTimeOffset.UtcNow,
+                TemporaryFailureCountSinceLastHandledMessage = 1001
+            });
+
+            var result = (await healthCheck.CheckHealthAsync(new HealthCheckContext())).Status;
+
+            Assert.Equal(HealthStatus.Healthy, result);
+        }
+
+        private static TooManyTemporaryFailuresHealthCheck<string> CreateHealthCheck(
+            TooManyTemporaryFailuresStatistics<string> temporaryFailuresStatistics)
+        {
+            var options = new TooManyTemporaryFailuresOptions();
+            return new TooManyTemporaryFailuresHealthCheck<string>(
+                new OptionsWrapper<TooManyTemporaryFailuresOptions>(options), temporaryFailuresStatistics);
+        }
+    }
+}

--- a/test/Motor.Extensions.Hosting_UnitTest/HealthChecks/TooManyTemporaryFailuresStatisticsTest.cs
+++ b/test/Motor.Extensions.Hosting_UnitTest/HealthChecks/TooManyTemporaryFailuresStatisticsTest.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Motor.Extensions.Hosting.Abstractions;
+using Motor.Extensions.Hosting.HealthChecks;
+using Xunit;
+
+namespace Motor.Extensions.Hosting_UnitTest.HealthChecks
+{
+    public class TooManyTemporaryFailuresStatisticsTest
+    {
+        [Theory]
+        [InlineData(ProcessedMessageStatus.Success)]
+        [InlineData(ProcessedMessageStatus.InvalidInput)]
+        public async void RegisterMessageStatusAsync_StatusHandledCorrectly_SetLastHandledMessage(
+            ProcessedMessageStatus status)
+        {
+            var tooManyTemporaryFailuresStatistics = new TooManyTemporaryFailuresStatistics<string>();
+            var beforeRegister = DateTimeOffset.UtcNow;
+
+            await tooManyTemporaryFailuresStatistics.RegisterMessageStatusAsync(status);
+
+            Assert.InRange(tooManyTemporaryFailuresStatistics.LastHandledMessageAt, beforeRegister,
+                DateTimeOffset.UtcNow);
+        }
+
+        [Theory]
+        [InlineData(ProcessedMessageStatus.CriticalFailure)]
+        [InlineData(ProcessedMessageStatus.TemporaryFailure)]
+        public async void RegisterMessageStatusAsync_StatusNotHandledCorrectly_DoesNotSetLastHandledMessage(
+            ProcessedMessageStatus status)
+        {
+            var tooManyTemporaryFailuresStatistics = new TooManyTemporaryFailuresStatistics<string>();
+            var beforeRegister = DateTimeOffset.UtcNow;
+
+            await tooManyTemporaryFailuresStatistics.RegisterMessageStatusAsync(status);
+
+            Assert.NotInRange(tooManyTemporaryFailuresStatistics.LastHandledMessageAt, beforeRegister,
+                DateTimeOffset.UtcNow);
+        }
+
+        [Theory]
+        [InlineData(1, ProcessedMessageStatus.TemporaryFailure)]
+        [InlineData(4, ProcessedMessageStatus.TemporaryFailure)]
+        [InlineData(1, ProcessedMessageStatus.CriticalFailure)]
+        [InlineData(4, ProcessedMessageStatus.CriticalFailure)]
+        public async void RegisterMessageStatusAsync_StatusNotHandledCorrectly_IncreasesTemporaryFailureCount(
+            uint count, ProcessedMessageStatus status)
+        {
+            var tooManyTemporaryFailuresStatistics = new TooManyTemporaryFailuresStatistics<string>();
+
+            for (uint i = 0; i < count; i++)
+            {
+                await tooManyTemporaryFailuresStatistics.RegisterMessageStatusAsync(status);
+            }
+
+            Assert.Equal(count, tooManyTemporaryFailuresStatistics.TemporaryFailureCountSinceLastHandledMessage);
+        }
+
+        [Theory]
+        [InlineData(ProcessedMessageStatus.Success)]
+        [InlineData(ProcessedMessageStatus.InvalidInput)]
+        public async void RegisterMessageStatusAsync_StatusHandledCorrectly_ResetTemporaryFailureCount(
+            ProcessedMessageStatus status)
+        {
+            var tooManyTemporaryFailuresStatistics = new TooManyTemporaryFailuresStatistics<string>
+            {
+                TemporaryFailureCountSinceLastHandledMessage = 100
+            };
+
+            await tooManyTemporaryFailuresStatistics.RegisterMessageStatusAsync(status);
+
+            Assert.Equal((uint)0, tooManyTemporaryFailuresStatistics.TemporaryFailureCountSinceLastHandledMessage);
+        }
+
+        [Fact]
+        public async void
+            RegisterMessageStatusAsync_ManyStatusesNotHandledCorrectlyInParallel_CorrectTemporaryFailureCount()
+        {
+            var tooManyTemporaryFailuresStatistics = new TooManyTemporaryFailuresStatistics<string>();
+            var notHandledCorrectlyTasks = new List<Task>(100);
+            var startSignal = new SemaphoreSlim(0, 100);
+            for (var i = 0; i < 100; i++)
+            {
+                notHandledCorrectlyTasks.Add(IncreaseTemporaryFailureCount(startSignal,
+                    tooManyTemporaryFailuresStatistics));
+            }
+            startSignal.Release(100);
+
+            await Task.WhenAll(notHandledCorrectlyTasks);
+
+            Assert.Equal((uint)100, tooManyTemporaryFailuresStatistics.TemporaryFailureCountSinceLastHandledMessage);
+        }
+
+        private static async Task IncreaseTemporaryFailureCount(SemaphoreSlim startSignal,
+            TooManyTemporaryFailuresStatistics<string> tooManyTemporaryFailuresStatistics)
+        {
+            await startSignal.WaitAsync();
+
+            await tooManyTemporaryFailuresStatistics.RegisterMessageStatusAsync(ProcessedMessageStatus
+                .TemporaryFailure);
+        }
+    }
+}


### PR DESCRIPTION
The health check fails when too many temporary failures were registered and the last successful message was processed too long ago. This should help for services that enter a state where they basically completely stop working and just fail for every consumed message.

Fixes #118

Co-authored-by: Jan Jansen <jan.jansen@gdata.de>
Co-authored-by: Florian Grieskamp <florian.grieskamp@gdata.de>
Signed-off-by: Florian Hockmann <fh@florian-hockmann.de>