### PR TITLE
Make global ThreadPool configurable

### DIFF
--- a/Motor.NET.sln
+++ b/Motor.NET.sln
@@ -105,6 +105,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsumeSQS", "examples\Cons
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Motor.Extensions.Hosting.Bridge", "src\Motor.Extensions.Hosting.Bridge\Motor.Extensions.Hosting.Bridge.csproj", "{62234AB3-F8B0-41A0-B3AE-988D7A26F91C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Motor.Extensions.Utilities_UnitTest", "test\Motor.Extensions.Utilities_UnitTest\Motor.Extensions.Utilities_UnitTest.csproj", "{B51A4631-F1C4-44A6-9F3C-F0AD0AE65697}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -643,6 +645,18 @@ Global
 		{62234AB3-F8B0-41A0-B3AE-988D7A26F91C}.Release|x64.Build.0 = Release|Any CPU
 		{62234AB3-F8B0-41A0-B3AE-988D7A26F91C}.Release|x86.ActiveCfg = Release|Any CPU
 		{62234AB3-F8B0-41A0-B3AE-988D7A26F91C}.Release|x86.Build.0 = Release|Any CPU
+		{B51A4631-F1C4-44A6-9F3C-F0AD0AE65697}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B51A4631-F1C4-44A6-9F3C-F0AD0AE65697}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B51A4631-F1C4-44A6-9F3C-F0AD0AE65697}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B51A4631-F1C4-44A6-9F3C-F0AD0AE65697}.Debug|x64.Build.0 = Debug|Any CPU
+		{B51A4631-F1C4-44A6-9F3C-F0AD0AE65697}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B51A4631-F1C4-44A6-9F3C-F0AD0AE65697}.Debug|x86.Build.0 = Debug|Any CPU
+		{B51A4631-F1C4-44A6-9F3C-F0AD0AE65697}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B51A4631-F1C4-44A6-9F3C-F0AD0AE65697}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B51A4631-F1C4-44A6-9F3C-F0AD0AE65697}.Release|x64.ActiveCfg = Release|Any CPU
+		{B51A4631-F1C4-44A6-9F3C-F0AD0AE65697}.Release|x64.Build.0 = Release|Any CPU
+		{B51A4631-F1C4-44A6-9F3C-F0AD0AE65697}.Release|x86.ActiveCfg = Release|Any CPU
+		{B51A4631-F1C4-44A6-9F3C-F0AD0AE65697}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -692,6 +706,7 @@ Global
 		{3FF292B7-E167-4687-8813-FCBC05B139B9} = {ADD2EBBA-A839-4E4A-9253-CDE29A372F07}
 		{76AF0280-E7F6-4853-A69F-71194F07EA9E} = {3DC7D216-6908-4759-B86F-759FDAE393D9}
 		{62234AB3-F8B0-41A0-B3AE-988D7A26F91C} = {749B1421-3177-4C7A-A66B-541BD4E925B0}
+		{B51A4631-F1C4-44A6-9F3C-F0AD0AE65697} = {ADD2EBBA-A839-4E4A-9253-CDE29A372F07}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5E91C34C-3AEC-4084-BA02-753C9236AA34}

--- a/shared.csproj
+++ b/shared.csproj
@@ -1,7 +1,7 @@
 <Project>
 
     <PropertyGroup>
-        <Version>0.6.8</Version>
+        <Version>0.6.9</Version>
         <LangVersion>9</LangVersion>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>CS8600;CS8602;CS8625;CS8618;CS8604;CS8601</WarningsAsErrors>

--- a/src/Motor.Extensions.Diagnostics.Metrics/Motor.Extensions.Diagnostics.Metrics.csproj
+++ b/src/Motor.Extensions.Diagnostics.Metrics/Motor.Extensions.Diagnostics.Metrics.csproj
@@ -7,6 +7,12 @@
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
+    
+    <ItemGroup>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+            <_Parameter1>Motor.Extensions.Diagnostics.Metrics_UnitTest</_Parameter1>
+        </AssemblyAttribute>
+    </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="Prometheus.Client" Version="4.4.0" />

--- a/src/Motor.Extensions.Diagnostics.Metrics/ThreadPoolGauge.cs
+++ b/src/Motor.Extensions.Diagnostics.Metrics/ThreadPoolGauge.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using System.Threading;
+using Prometheus.Client;
+using Prometheus.Client.Collectors;
+using Prometheus.Client.MetricsWriter;
+
+namespace Motor.Extensions.Diagnostics.Metrics
+{
+    internal class ThreadPoolGauge : ICollector
+    {
+        private static readonly string[] Labels =
+        {
+            "ThreadPoolOption"
+        };
+
+        internal static readonly MetricConfiguration ThreadPoolGaugeConfig = new(
+            "ThreadPoolState",
+            "Expose information about the internal .NET global ThreadPool",
+            Labels,
+            false
+        );
+
+        public void Collect(IMetricsWriter writer)
+        {
+            ThreadPool.GetMaxThreads(out var maxWorkerThreads, out var maxCompletionThreads);
+            ThreadPool.GetMinThreads(out var minWorkerThreads, out var minCompletionThreads);
+            ThreadPool.GetAvailableThreads(out var availableWorkerThreads, out var availableCompletionThreads);
+
+            WriteSample(writer, minWorkerThreads, nameof(minWorkerThreads));
+            WriteSample(writer, minCompletionThreads, nameof(minCompletionThreads));
+            WriteSample(writer, maxWorkerThreads, nameof(maxWorkerThreads));
+            WriteSample(writer, maxCompletionThreads, nameof(maxCompletionThreads));
+            WriteSample(writer, ThreadPool.ThreadCount, nameof(ThreadPool.ThreadCount));
+            WriteSample(writer, availableWorkerThreads, nameof(availableWorkerThreads));
+            WriteSample(writer, availableCompletionThreads, nameof(availableCompletionThreads));
+        }
+
+        public CollectorConfiguration Configuration => ThreadPoolGaugeConfig;
+
+        public IReadOnlyList<string> MetricNames => new[] { ThreadPoolGaugeConfig.Name };
+
+        private void WriteSample(IMetricsWriter writer, double value, string labelValue)
+        {
+            writer.WriteSample(
+                value,
+                string.Empty,
+                Labels,
+                new[] { Capitalize(labelValue) });
+        }
+
+        private static string Capitalize(string labelValue) =>
+            char.ToUpperInvariant(labelValue[0]) + labelValue.Substring(1);
+    }
+}

--- a/src/Motor.Extensions.Utilities/MotorHostBuilder.cs
+++ b/src/Motor.Extensions.Utilities/MotorHostBuilder.cs
@@ -25,6 +25,12 @@ namespace Motor.Extensions.Utilities
             _config = new ConfigurationBuilder()
                 .AddEnvironmentVariables(MotorHostDefaults.OptionsPrefix)
                 .Build();
+
+            _builder.ConfigureServices(collection =>
+            {
+                collection.Configure<ThreadPoolOptions>("ThreadPool", _config);
+                collection.AddHostedService<ThreadPoolSetupService>();
+            });
         }
 
         public IHostBuilder ConfigureHostConfiguration(Action<IConfigurationBuilder> configureDelegate)

--- a/src/Motor.Extensions.Utilities/ThreadPoolSetupService.cs
+++ b/src/Motor.Extensions.Utilities/ThreadPoolSetupService.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace Motor.Extensions.Utilities
+{
+    public record ThreadPoolOptions
+    {
+        public int MinWorkerThreads { get; init; } = Environment.ProcessorCount;
+        public int MinCompletionThreads { get; init; } = Environment.ProcessorCount;
+    }
+
+    public sealed class ThreadPoolSetupService : IHostedService
+    {
+        private readonly IOptions<ThreadPoolOptions> _threadPoolOptions;
+
+
+        public ThreadPoolSetupService(IOptions<ThreadPoolOptions> threadPoolOptions)
+        {
+            _threadPoolOptions = threadPoolOptions;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken = default)
+        {
+            SetupGlobalThreadPool(_threadPoolOptions.Value.MinWorkerThreads,
+                _threadPoolOptions.Value.MinCompletionThreads);
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        private static void SetupGlobalThreadPool(int desiredMinWorkerThreads, int desiredMinCompletionThreads)
+        {
+            if (desiredMinWorkerThreads <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(desiredMinWorkerThreads), desiredMinWorkerThreads, "Minimum number of worker threads must be positive");
+            }
+
+            if (desiredMinCompletionThreads <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(desiredMinCompletionThreads), desiredMinCompletionThreads, "Minimum number of completion port threads must be positive");
+            }
+
+            ThreadPool.GetMinThreads(out var minWorkerThreads, out var minCompletionThreads);
+            ThreadPool.GetMaxThreads(out var maxWorkerThreads, out var maxCompletionThreads);
+
+            desiredMinWorkerThreads = Math.Min(desiredMinWorkerThreads, maxWorkerThreads);
+            desiredMinCompletionThreads = Math.Min(desiredMinCompletionThreads, maxCompletionThreads);
+
+            desiredMinWorkerThreads = Math.Max(minWorkerThreads, desiredMinWorkerThreads);
+            desiredMinCompletionThreads = Math.Max(minCompletionThreads, desiredMinCompletionThreads);
+            ThreadPool.SetMinThreads(desiredMinWorkerThreads, desiredMinCompletionThreads);
+        }
+    }
+}

--- a/test/Motor.Extensions.Diagnostics.Metrics_UnitTest/ThreadPoolGaugeTest.cs
+++ b/test/Motor.Extensions.Diagnostics.Metrics_UnitTest/ThreadPoolGaugeTest.cs
@@ -1,0 +1,53 @@
+using Moq;
+using Motor.Extensions.Diagnostics.Metrics;
+using Prometheus.Client.MetricsWriter;
+using Xunit;
+
+namespace Motor.Extensions.Diagnostics.Metrics_UnitTest
+{
+    public class ThreadPoolGaugeTest
+    {
+        private static readonly string[] ExpectedLabelValues = {
+            "MinWorkerThreads",
+            "MinCompletionThreads",
+            "MaxWorkerThreads",
+            "MaxCompletionThreads",
+            "ThreadCount",
+            "AvailableWorkerThreads",
+            "AvailableCompletionThreads"
+        };
+
+        [Fact]
+        public void TestCollect_MockedWriter_ThreadPoolMetrics()
+        {
+            var threadPoolGauge = new ThreadPoolGauge();
+            var writerMock = new Mock<IMetricsWriter>();
+            var sampleWriterMock = new Mock<ISampleWriter>();
+            var labelWriterMock = new Mock<ILabelWriter>();
+
+            writerMock
+                .Setup(w => w.StartSample(string.Empty))
+                .Returns(sampleWriterMock.Object);
+            sampleWriterMock
+                .Setup(w => w.StartLabels())
+                .Returns(labelWriterMock.Object);
+            sampleWriterMock
+                .Setup(w => w.WriteValue(It.Is<double>(d => d > 0)));
+            sampleWriterMock
+                .Setup(w => w.EndSample());
+            labelWriterMock
+                .Setup(w => w.WriteLabel("ThreadPoolState", It.IsIn(ExpectedLabelValues)));
+
+            threadPoolGauge.Collect(writerMock.Object);
+
+            writerMock.Verify(w => w.StartSample(string.Empty), Times.Exactly(ExpectedLabelValues.Length));
+            sampleWriterMock.Verify(w => w.StartLabels(), Times.Exactly(ExpectedLabelValues.Length));
+            sampleWriterMock.Verify(w => w.WriteValue(It.IsAny<double>()), Times.Exactly(ExpectedLabelValues.Length));
+            sampleWriterMock.Verify(w => w.EndSample(), Times.Exactly(ExpectedLabelValues.Length));
+            foreach (var expectedLabelValue in ExpectedLabelValues)
+            {
+                labelWriterMock.Verify(w => w.WriteLabel("ThreadPoolOption", expectedLabelValue), Times.Once);
+            }
+        }
+    }
+}

--- a/test/Motor.Extensions.Utilities_UnitTest/Motor.Extensions.Utilities_UnitTest.csproj
+++ b/test/Motor.Extensions.Utilities_UnitTest/Motor.Extensions.Utilities_UnitTest.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net5.0</TargetFramework>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="1.3.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Motor.Extensions.Utilities\Motor.Extensions.Utilities.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/test/Motor.Extensions.Utilities_UnitTest/ThreadPoolSetupServiceTest.cs
+++ b/test/Motor.Extensions.Utilities_UnitTest/ThreadPoolSetupServiceTest.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Threading;
+using Microsoft.Extensions.Options;
+using Motor.Extensions.Utilities;
+using Xunit;
+
+namespace Motor.Extensions.Utilities_UnitTest
+{
+    public class ThreadPoolSetupServiceTest
+    {
+        [Fact]
+        public async void TestStartAsync_DefaultSettings_EnvironmentProcessorCount()
+        {
+            ThreadPool.GetMinThreads(out var origMinWorkerThreads, out var origMinCompletionThreads);
+            var threadPoolOptions = new ThreadPoolOptions();
+            var threadPoolSetupSvc = new ThreadPoolSetupService(Options.Create(threadPoolOptions));
+
+            await threadPoolSetupSvc.StartAsync();
+
+            ThreadPool.GetMinThreads(out var newWorkerThreads, out var newCompletionThreads);
+            Assert.Equal(Environment.ProcessorCount, newWorkerThreads);
+            Assert.Equal(Environment.ProcessorCount, newCompletionThreads);
+
+            /* Restore previous values */
+            ThreadPool.SetMinThreads(origMinWorkerThreads, origMinCompletionThreads);
+        }
+
+        [Fact]
+        public async void TestStartAsync_WorkerThreadCountNegative_ArgumentOutOfRangeException()
+        {
+            var threadPoolOptions = new ThreadPoolOptions { MinWorkerThreads = -1 };
+            var threadPoolSetupSvc = new ThreadPoolSetupService(Options.Create(threadPoolOptions));
+
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await threadPoolSetupSvc.StartAsync());
+        }
+
+        [Fact]
+        public async void TestStartAsync_CompletionPortThreadCountNegative_ArgumentOutOfRangeException()
+        {
+            var threadPoolOptions = new ThreadPoolOptions { MinCompletionThreads = -1 };
+            var threadPoolSetupSvc = new ThreadPoolSetupService(Options.Create(threadPoolOptions));
+
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await threadPoolSetupSvc.StartAsync());
+        }
+
+        [Fact]
+        public async void TestStartAsync_SettingsOverride_Override()
+        {
+            ThreadPool.GetMinThreads(out var origMinWorkerThreads, out var origMinCompletionThreads);
+            var doubleProcCount = Environment.ProcessorCount * 2;
+            var threadPoolOptions = new ThreadPoolOptions
+            {
+                MinWorkerThreads = doubleProcCount,
+                MinCompletionThreads = doubleProcCount
+            };
+            var threadPoolSetupSvc = new ThreadPoolSetupService(Options.Create(threadPoolOptions));
+
+            await threadPoolSetupSvc.StartAsync();
+
+            ThreadPool.GetMinThreads(out var newWorkerThreads, out var newCompletionThreads);
+            Assert.Equal(doubleProcCount, newWorkerThreads);
+            Assert.Equal(doubleProcCount, newCompletionThreads);
+
+            /* Restore previous values */
+            ThreadPool.SetMinThreads(origMinWorkerThreads, origMinCompletionThreads);
+        }
+
+        [Fact]
+        public async void TestStartAsync_GreaterThanMax_HonorMax()
+        {
+            ThreadPool.GetMinThreads(out var origMinWorkerThreads, out var origMinCompletionThreads);
+            ThreadPool.GetMaxThreads(out var origMaxWorkerThreads, out var origMaxCompletionThreads);
+            var syntheticMaxWorker = Environment.ProcessorCount;
+            var syntheticMaxCompletion = Environment.ProcessorCount;
+            ThreadPool.SetMaxThreads(syntheticMaxWorker, syntheticMaxCompletion);
+            var doubleProcCount = Environment.ProcessorCount * 2;
+            var threadPoolOptions = new ThreadPoolOptions
+            {
+                MinWorkerThreads = doubleProcCount,
+                MinCompletionThreads = doubleProcCount
+            };
+            var threadPoolSetupSvc = new ThreadPoolSetupService(Options.Create(threadPoolOptions));
+
+            await threadPoolSetupSvc.StartAsync();
+
+            ThreadPool.GetMinThreads(out var newWorkerThreads, out var newCompletionThreads);
+            Assert.Equal(syntheticMaxWorker, newWorkerThreads);
+            Assert.Equal(syntheticMaxCompletion, newCompletionThreads);
+
+            /* Restore previous values */
+            ThreadPool.SetMinThreads(origMinWorkerThreads, origMinCompletionThreads);
+            ThreadPool.SetMaxThreads(origMaxWorkerThreads, origMaxCompletionThreads);
+        }
+    }
+}


### PR DESCRIPTION
- allow to override minimum worker and completion port threads to avoid (containerized) scenarios where applications are suddenly 'single-threaded' when the .NET runtime detects a single host CPU due to configured resource limits
- export metrics of the global thread pool to allow further investigations of performance bottlenecks

Co-authored by: @rngcntr 