### PR TITLE
Add gzip compression

### DIFF
--- a/Motor.NET.sln
+++ b/Motor.NET.sln
@@ -109,6 +109,14 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Motor.Extensions.Utilities_
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Motor.Extensions.Diagnostics.Telemetry", "src\Motor.Extensions.Diagnostics.Telemetry\Motor.Extensions.Diagnostics.Telemetry.csproj", "{6BCF181C-1BAA-4B9C-8E32-EB46409CDF01}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Motor.Extensions.Compression.Abstractions", "src\Motor.Extensions.Compression.Abstractions\Motor.Extensions.Compression.Abstractions.csproj", "{EDCD789B-FD17-449E-80D5-70E6E93F35F1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Motor.Extensions.Compression.Gzip", "src\Motor.Extensions.Compression.Gzip\Motor.Extensions.Compression.Gzip.csproj", "{ADAEFE79-278A-4945-9FBD-4D0DA81237FC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Motor.Extensions.Compression.Gzip_UnitTest", "test\Motor.Extensions.Compression.Gzip_UnitTest\Motor.Extensions.Compression.Gzip_UnitTest.csproj", "{7A219941-ABC1-4586-9C6E-8D268D13F96F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Motor.Extensions.Compression.Abstractions_UnitTest", "test\Motor.Extensions.Compression.Abstractions_UnitTest\Motor.Extensions.Compression.Abstractions_UnitTest.csproj", "{C1385EB8-4F54-4869-83A0-72D85A5E986C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -671,6 +679,54 @@ Global
 		{6BCF181C-1BAA-4B9C-8E32-EB46409CDF01}.Release|x64.Build.0 = Release|Any CPU
 		{6BCF181C-1BAA-4B9C-8E32-EB46409CDF01}.Release|x86.ActiveCfg = Release|Any CPU
 		{6BCF181C-1BAA-4B9C-8E32-EB46409CDF01}.Release|x86.Build.0 = Release|Any CPU
+		{EDCD789B-FD17-449E-80D5-70E6E93F35F1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EDCD789B-FD17-449E-80D5-70E6E93F35F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EDCD789B-FD17-449E-80D5-70E6E93F35F1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EDCD789B-FD17-449E-80D5-70E6E93F35F1}.Debug|x64.Build.0 = Debug|Any CPU
+		{EDCD789B-FD17-449E-80D5-70E6E93F35F1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EDCD789B-FD17-449E-80D5-70E6E93F35F1}.Debug|x86.Build.0 = Debug|Any CPU
+		{EDCD789B-FD17-449E-80D5-70E6E93F35F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EDCD789B-FD17-449E-80D5-70E6E93F35F1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EDCD789B-FD17-449E-80D5-70E6E93F35F1}.Release|x64.ActiveCfg = Release|Any CPU
+		{EDCD789B-FD17-449E-80D5-70E6E93F35F1}.Release|x64.Build.0 = Release|Any CPU
+		{EDCD789B-FD17-449E-80D5-70E6E93F35F1}.Release|x86.ActiveCfg = Release|Any CPU
+		{EDCD789B-FD17-449E-80D5-70E6E93F35F1}.Release|x86.Build.0 = Release|Any CPU
+		{ADAEFE79-278A-4945-9FBD-4D0DA81237FC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ADAEFE79-278A-4945-9FBD-4D0DA81237FC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ADAEFE79-278A-4945-9FBD-4D0DA81237FC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{ADAEFE79-278A-4945-9FBD-4D0DA81237FC}.Debug|x64.Build.0 = Debug|Any CPU
+		{ADAEFE79-278A-4945-9FBD-4D0DA81237FC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{ADAEFE79-278A-4945-9FBD-4D0DA81237FC}.Debug|x86.Build.0 = Debug|Any CPU
+		{ADAEFE79-278A-4945-9FBD-4D0DA81237FC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ADAEFE79-278A-4945-9FBD-4D0DA81237FC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ADAEFE79-278A-4945-9FBD-4D0DA81237FC}.Release|x64.ActiveCfg = Release|Any CPU
+		{ADAEFE79-278A-4945-9FBD-4D0DA81237FC}.Release|x64.Build.0 = Release|Any CPU
+		{ADAEFE79-278A-4945-9FBD-4D0DA81237FC}.Release|x86.ActiveCfg = Release|Any CPU
+		{ADAEFE79-278A-4945-9FBD-4D0DA81237FC}.Release|x86.Build.0 = Release|Any CPU
+		{7A219941-ABC1-4586-9C6E-8D268D13F96F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7A219941-ABC1-4586-9C6E-8D268D13F96F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7A219941-ABC1-4586-9C6E-8D268D13F96F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7A219941-ABC1-4586-9C6E-8D268D13F96F}.Debug|x64.Build.0 = Debug|Any CPU
+		{7A219941-ABC1-4586-9C6E-8D268D13F96F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7A219941-ABC1-4586-9C6E-8D268D13F96F}.Debug|x86.Build.0 = Debug|Any CPU
+		{7A219941-ABC1-4586-9C6E-8D268D13F96F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7A219941-ABC1-4586-9C6E-8D268D13F96F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7A219941-ABC1-4586-9C6E-8D268D13F96F}.Release|x64.ActiveCfg = Release|Any CPU
+		{7A219941-ABC1-4586-9C6E-8D268D13F96F}.Release|x64.Build.0 = Release|Any CPU
+		{7A219941-ABC1-4586-9C6E-8D268D13F96F}.Release|x86.ActiveCfg = Release|Any CPU
+		{7A219941-ABC1-4586-9C6E-8D268D13F96F}.Release|x86.Build.0 = Release|Any CPU
+		{C1385EB8-4F54-4869-83A0-72D85A5E986C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C1385EB8-4F54-4869-83A0-72D85A5E986C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C1385EB8-4F54-4869-83A0-72D85A5E986C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C1385EB8-4F54-4869-83A0-72D85A5E986C}.Debug|x64.Build.0 = Debug|Any CPU
+		{C1385EB8-4F54-4869-83A0-72D85A5E986C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C1385EB8-4F54-4869-83A0-72D85A5E986C}.Debug|x86.Build.0 = Debug|Any CPU
+		{C1385EB8-4F54-4869-83A0-72D85A5E986C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C1385EB8-4F54-4869-83A0-72D85A5E986C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C1385EB8-4F54-4869-83A0-72D85A5E986C}.Release|x64.ActiveCfg = Release|Any CPU
+		{C1385EB8-4F54-4869-83A0-72D85A5E986C}.Release|x64.Build.0 = Release|Any CPU
+		{C1385EB8-4F54-4869-83A0-72D85A5E986C}.Release|x86.ActiveCfg = Release|Any CPU
+		{C1385EB8-4F54-4869-83A0-72D85A5E986C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -722,6 +778,10 @@ Global
 		{62234AB3-F8B0-41A0-B3AE-988D7A26F91C} = {749B1421-3177-4C7A-A66B-541BD4E925B0}
 		{B51A4631-F1C4-44A6-9F3C-F0AD0AE65697} = {ADD2EBBA-A839-4E4A-9253-CDE29A372F07}
 		{6BCF181C-1BAA-4B9C-8E32-EB46409CDF01} = {749B1421-3177-4C7A-A66B-541BD4E925B0}
+		{EDCD789B-FD17-449E-80D5-70E6E93F35F1} = {749B1421-3177-4C7A-A66B-541BD4E925B0}
+		{ADAEFE79-278A-4945-9FBD-4D0DA81237FC} = {749B1421-3177-4C7A-A66B-541BD4E925B0}
+		{7A219941-ABC1-4586-9C6E-8D268D13F96F} = {ADD2EBBA-A839-4E4A-9253-CDE29A372F07}
+		{C1385EB8-4F54-4869-83A0-72D85A5E986C} = {ADD2EBBA-A839-4E4A-9253-CDE29A372F07}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5E91C34C-3AEC-4084-BA02-753C9236AA34}

--- a/Readme.md
+++ b/Readme.md
@@ -24,13 +24,13 @@ You find working examples for different use-cases under the [examples](./example
 
 ## Support Matrix
 
-| Component | Consume | Publish | CloudEvents | Metrics | Custom |
-| --- | --- | --- | --- | --- | --- |
-| RabbitMQ | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | priority, dynamic routing |
-| Kafka | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | partitioning key, dynamic topic |
-| Http | (:heavy_check_mark:) | (:heavy_check_mark:) | :x: |:heavy_check_mark:| |
-| Timer | (:heavy_check_mark:) | - | :x: | :x:| |
-| SQS | (:heavy_check_mark:) | - | :x: | :x:| |
+| Component | Consume | Publish | CloudEvents | Metrics | Compression | Custom |
+| --- | --- | --- | --- | --- | --- | --- |
+| RabbitMQ | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | priority, dynamic routing |
+| Kafka | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | partitioning key, dynamic topic |
+| Http | (:heavy_check_mark:) | (:heavy_check_mark:) | :x: |:heavy_check_mark: | :x: | |
+| Timer | (:heavy_check_mark:) | - | :x: | :x: | :x: | |
+| SQS | (:heavy_check_mark:) | - | :x: | :x: | :x: | |
 
 ## Health Checks
 
@@ -39,6 +39,16 @@ Motor.NET comes by default already with two health checks for message processing
 - `MessageProcessingHealthCheck`: Fails when no messages were consumed in a certain time frame from the Motor.NET internal queue although it has at least some messages.
 - `TooManyTemporaryFailuresHealthCheck`: Fails when too many messages led to a failure since the last message was correctly handled (either successful or as invalid input).
 
+## Compression (Optional)
+
+[Gzip][gzip] compression can optionally be enabled for consumers and publishers. By enabling it for a publisher, the payload of
+all published messages will be compressed. Enabling it for a consumer will allow the consumer to decompress these
+messages. Consumers can however still consume uncompressed messages. This should make it easy to enable compression in
+an existing environment that does not use compression yet. It just needs to be enabled first for the consumers and
+afterwards for the publishers.
+
 ## License
 
 Motor.NET is provided under the [MIT](./LICENSE) license.
+
+[gzip]: https://www.gnu.org/software/gzip/

--- a/examples/ConsumeAndPublishWithRabbitMQ/ConsumeAndPublishWithRabbitMQ.csproj
+++ b/examples/ConsumeAndPublishWithRabbitMQ/ConsumeAndPublishWithRabbitMQ.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Motor.Extensions.Compression.Gzip\Motor.Extensions.Compression.Gzip.csproj" />
     <ProjectReference Include="..\..\src\Motor.Extensions.Conversion.SystemJson\Motor.Extensions.Conversion.SystemJson.csproj" />
     <ProjectReference Include="..\..\src\Motor.Extensions.Hosting.RabbitMQ\Motor.Extensions.Hosting.RabbitMQ.csproj" />
     <ProjectReference Include="..\..\src\Motor.Extensions.Utilities\Motor.Extensions.Utilities.csproj" />

--- a/examples/ConsumeAndPublishWithRabbitMQ/Program.cs
+++ b/examples/ConsumeAndPublishWithRabbitMQ/Program.cs
@@ -2,6 +2,7 @@ using ConsumeAndPublishWithRabbitMQ;
 using ConsumeAndPublishWithRabbitMQ.Model;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Motor.Extensions.Compression.Gzip;
 using Motor.Extensions.Conversion.SystemJson;
 using Motor.Extensions.Hosting.Abstractions;
 using Motor.Extensions.Hosting.Consumer;
@@ -25,6 +26,9 @@ await MotorHost.CreateDefaultBuilder()
         builder.AddRabbitMQ();
         // The encoding of the incoming message, such that the handler is able to deserialize the message
         builder.AddSystemJson();
+        // (Optional) Enable support for incoming messages that are gzip compressed. Uncompressed messages will still
+        //  work to make the migration to compression backwards-compatible.
+        builder.AddGzipDecompression();
     })
     // Add the outgoing communication module.
     .ConfigurePublisher<OutputMessage>((_, builder) =>
@@ -33,5 +37,7 @@ await MotorHost.CreateDefaultBuilder()
         builder.AddRabbitMQ();
         // The encoding of the outgoing message, such that the handler is able to serialize the message
         builder.AddSystemJson();
+        // (Optional) Compress the serialized data of the outgoing message with gzip.
+        builder.AddGzipCompression();
     })
     .RunConsoleAsync();

--- a/shared.csproj
+++ b/shared.csproj
@@ -1,7 +1,7 @@
 <Project>
 
     <PropertyGroup>
-        <Version>0.6.13</Version>
+        <Version>0.6.14</Version>
         <LangVersion>9</LangVersion>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>CS8600;CS8602;CS8625;CS8618;CS8604;CS8601</WarningsAsErrors>

--- a/src/Motor.Extensions.Compression.Abstractions/CompressionTypeExtension.cs
+++ b/src/Motor.Extensions.Compression.Abstractions/CompressionTypeExtension.cs
@@ -2,48 +2,51 @@ using System;
 using System.Collections.Generic;
 using CloudNative.CloudEvents;
 
-namespace Motor.Extensions.Hosting.Kafka
+namespace Motor.Extensions.Compression.Abstractions
 {
-    public class KafkaTopicExtension : ICloudEventExtension
+    public class CompressionTypeExtension : ICloudEventExtension
     {
-        public const string TopicAttributeName = "topic";
+        private const string CompressionTypeAttributeName = "compressionType";
         private IDictionary<string, object> _attributes = new Dictionary<string, object>();
 
-        public KafkaTopicExtension(string topic)
+        public CompressionTypeExtension(string compressionType)
         {
-            Topic = topic;
+            CompressionType = compressionType;
         }
 
-        public string? Topic
+        public string? CompressionType
         {
-            get => (string?)_attributes[TopicAttributeName];
-            set
-            {
-                if (value is not null) _attributes[TopicAttributeName] = value;
-            }
+            get => (string?)_attributes[CompressionTypeAttributeName];
+            private init => _attributes[CompressionTypeAttributeName] =
+                value ?? throw new ArgumentNullException(nameof(CompressionType));
         }
 
         public void Attach(CloudEvent cloudEvent)
         {
             var eventAttributes = cloudEvent.GetAttributes();
             if (_attributes == eventAttributes)
+            {
                 // already done
                 return;
+            }
 
-            foreach (var attr in _attributes) eventAttributes[attr.Key] = attr.Value;
+            foreach (var (key, value) in _attributes)
+            {
+                eventAttributes[key] = value;
+            }
 
             _attributes = eventAttributes;
         }
 
         public bool ValidateAndNormalize(string key, ref object value)
         {
-            if (key is TopicAttributeName)
+            if (key is CompressionTypeAttributeName)
             {
                 return value switch
                 {
                     null => true,
                     string _ => true,
-                    _ => throw new InvalidOperationException("ErrorTopicValueIsNotAString")
+                    _ => throw new InvalidOperationException("ErrorCompressionTypeValueIsNotAString")
                 };
             }
 
@@ -55,7 +58,7 @@ namespace Motor.Extensions.Hosting.Kafka
 #pragma warning disable CS8603
         public Type GetAttributeType(string name)
         {
-            return name is TopicAttributeName ? typeof(string) : null;
+            return name is CompressionTypeAttributeName ? typeof(string) : null;
         }
     }
 }

--- a/src/Motor.Extensions.Compression.Abstractions/IMessageCompressor.cs
+++ b/src/Motor.Extensions.Compression.Abstractions/IMessageCompressor.cs
@@ -1,0 +1,11 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Motor.Extensions.Compression.Abstractions
+{
+    public interface IMessageCompressor
+    {
+        string CompressionType { get; }
+        Task<byte[]> CompressAsync(byte[] rawMessage, CancellationToken cancellationToken);
+    }
+}

--- a/src/Motor.Extensions.Compression.Abstractions/IMessageDecompressor.cs
+++ b/src/Motor.Extensions.Compression.Abstractions/IMessageDecompressor.cs
@@ -1,0 +1,11 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Motor.Extensions.Compression.Abstractions
+{
+    public interface IMessageDecompressor
+    {
+        string CompressionType { get; }
+        Task<byte[]> DecompressAsync(byte[] compressedMessage, CancellationToken cancellationToken);
+    }
+}

--- a/src/Motor.Extensions.Compression.Abstractions/Motor.Extensions.Compression.Abstractions.csproj
+++ b/src/Motor.Extensions.Compression.Abstractions/Motor.Extensions.Compression.Abstractions.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net5.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="CloudNative.CloudEvents" Version="1.3.80" />
+    </ItemGroup>
+
+    <Import Project="$(MSBuildThisFileDirectory)../../shared.csproj" />
+
+</Project>

--- a/src/Motor.Extensions.Compression.Abstractions/NoOpMessageCompressor.cs
+++ b/src/Motor.Extensions.Compression.Abstractions/NoOpMessageCompressor.cs
@@ -1,0 +1,18 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Motor.Extensions.Compression.Abstractions
+{
+
+    public class NoOpMessageCompressor : IMessageCompressor
+    {
+        public string CompressionType => NoOpCompressionType;
+
+        public const string NoOpCompressionType = "uncompressed";
+
+        public Task<byte[]> CompressAsync(byte[] rawMessage, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(rawMessage);
+        }
+    }
+}

--- a/src/Motor.Extensions.Compression.Abstractions/NoOpMessageDecompressor.cs
+++ b/src/Motor.Extensions.Compression.Abstractions/NoOpMessageDecompressor.cs
@@ -1,0 +1,15 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Motor.Extensions.Compression.Abstractions
+{
+    public class NoOpMessageDecompressor : IMessageDecompressor
+    {
+        public string CompressionType => NoOpMessageCompressor.NoOpCompressionType;
+
+        public Task<byte[]> DecompressAsync(byte[] compressedMessage, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(compressedMessage);
+        }
+    }
+}

--- a/src/Motor.Extensions.Compression.Gzip/GzipHostBuilderExtensions.cs
+++ b/src/Motor.Extensions.Compression.Gzip/GzipHostBuilderExtensions.cs
@@ -1,0 +1,21 @@
+using Motor.Extensions.Hosting.Abstractions;
+
+namespace Motor.Extensions.Compression.Gzip
+{
+    public static class GzipHostBuilderExtensions
+    {
+        public static IPublisherBuilder<TOut> AddGzipCompression<TOut>(this IPublisherBuilder<TOut> hostBuilder)
+            where TOut : notnull
+        {
+            hostBuilder.AddCompressor<GzipMessageCompressor>();
+            return hostBuilder;
+        }
+
+        public static IConsumerBuilder<TOut> AddGzipDecompression<TOut>(this IConsumerBuilder<TOut> hostBuilder)
+            where TOut : notnull
+        {
+            hostBuilder.AddDecompressor<GzipMessageDecompressor>();
+            return hostBuilder;
+        }
+    }
+}

--- a/src/Motor.Extensions.Compression.Gzip/GzipMessageCompressor.cs
+++ b/src/Motor.Extensions.Compression.Gzip/GzipMessageCompressor.cs
@@ -1,0 +1,26 @@
+using System.IO;
+using System.IO.Compression;
+using System.Threading;
+using System.Threading.Tasks;
+using Motor.Extensions.Compression.Abstractions;
+
+namespace Motor.Extensions.Compression.Gzip
+{
+    public class GzipMessageCompressor : IMessageCompressor
+    {
+        public string CompressionType => GzipCompressionType;
+
+        public const string GzipCompressionType = "gzip";
+
+        public async Task<byte[]> CompressAsync(byte[] rawMessage, CancellationToken cancellationToken)
+        {
+            await using var compressedStream = new MemoryStream();
+            //use using with explicit scope to close/flush the GZipStream before using the outputstream
+            await using (var zipStream = new GZipStream(compressedStream, CompressionMode.Compress))
+            {
+                await zipStream.WriteAsync(rawMessage, cancellationToken);
+            }
+            return compressedStream.ToArray();
+        }
+    }
+}

--- a/src/Motor.Extensions.Compression.Gzip/GzipMessageDecompressor.cs
+++ b/src/Motor.Extensions.Compression.Gzip/GzipMessageDecompressor.cs
@@ -1,0 +1,27 @@
+using System.IO;
+using System.IO.Compression;
+using System.Threading;
+using System.Threading.Tasks;
+using Motor.Extensions.Compression.Abstractions;
+
+namespace Motor.Extensions.Compression.Gzip
+{
+    public class GzipMessageDecompressor : IMessageDecompressor
+    {
+        public string CompressionType => GzipMessageCompressor.GzipCompressionType;
+
+        public async Task<byte[]> DecompressAsync(byte[] compressedMessage, CancellationToken cancellationToken)
+        {
+            var compressedStream = new MemoryStream(compressedMessage);
+
+            var output = new MemoryStream();
+            //use using with explicit scope to close/flush the GZipStream before using the outputstream
+            await using (var decompressionStream = new GZipStream(compressedStream, CompressionMode.Decompress))
+            {
+                await decompressionStream.CopyToAsync(output, cancellationToken);
+            }
+
+            return output.ToArray();
+        }
+    }
+}

--- a/src/Motor.Extensions.Compression.Gzip/Motor.Extensions.Compression.Gzip.csproj
+++ b/src/Motor.Extensions.Compression.Gzip/Motor.Extensions.Compression.Gzip.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net5.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Motor.Extensions.Compression.Abstractions\Motor.Extensions.Compression.Abstractions.csproj" />
+      <ProjectReference Include="..\Motor.Extensions.Hosting.Abstractions\Motor.Extensions.Hosting.Abstractions.csproj" />
+    </ItemGroup>
+
+    <Import Project="$(MSBuildThisFileDirectory)../../shared.csproj" />
+
+</Project>

--- a/src/Motor.Extensions.Hosting.Abstractions/IConsumerBuilder.cs
+++ b/src/Motor.Extensions.Hosting.Abstractions/IConsumerBuilder.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Motor.Extensions.Compression.Abstractions;
 using Motor.Extensions.Conversion.Abstractions;
 
 namespace Motor.Extensions.Hosting.Abstractions
@@ -10,6 +11,8 @@ namespace Motor.Extensions.Hosting.Abstractions
 
         public void AddConsumer<TConsumer>()
             where TConsumer : IMessageConsumer<T>;
+
+        void AddDecompressor<TDecompressor>() where TDecompressor : IMessageDecompressor;
 
         public void AddDeserializer<TDeserializer>()
             where TDeserializer : IMessageDeserializer<T>;

--- a/src/Motor.Extensions.Hosting.Abstractions/IPublisherBuilder.cs
+++ b/src/Motor.Extensions.Hosting.Abstractions/IPublisherBuilder.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Motor.Extensions.Compression.Abstractions;
 using Motor.Extensions.Conversion.Abstractions;
 
 namespace Motor.Extensions.Hosting.Abstractions
@@ -13,5 +14,8 @@ namespace Motor.Extensions.Hosting.Abstractions
 
         public void AddSerializer<TSerializer>()
             where TSerializer : IMessageSerializer<T>;
+
+        public void AddCompressor<TCompressor>()
+            where TCompressor : IMessageCompressor;
     }
 }

--- a/src/Motor.Extensions.Hosting.Abstractions/Motor.Extensions.Hosting.Abstractions.csproj
+++ b/src/Motor.Extensions.Hosting.Abstractions/Motor.Extensions.Hosting.Abstractions.csproj
@@ -11,6 +11,7 @@
     </ItemGroup>
     
     <ItemGroup>
+      <ProjectReference Include="..\Motor.Extensions.Compression.Abstractions\Motor.Extensions.Compression.Abstractions.csproj" />
       <ProjectReference Include="..\Motor.Extensions.Conversion.Abstractions\Motor.Extensions.Conversion.Abstractions.csproj" />
     </ItemGroup>
 

--- a/src/Motor.Extensions.Hosting.Consumer/ConsumerBuilder.cs
+++ b/src/Motor.Extensions.Hosting.Consumer/ConsumerBuilder.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Motor.Extensions.Compression.Abstractions;
 using Motor.Extensions.Conversion.Abstractions;
 using Motor.Extensions.Hosting.Abstractions;
 
@@ -22,6 +23,12 @@ namespace Motor.Extensions.Hosting.Consumer
         public void AddConsumer<TConsumer>() where TConsumer : IMessageConsumer<T>
         {
             _serviceCollection.AddTransient(typeof(IMessageConsumer<T>), typeof(TConsumer));
+            _serviceCollection.AddTransient<IMessageDecompressor, NoOpMessageDecompressor>();
+        }
+
+        public void AddDecompressor<TDecompressor>() where TDecompressor : IMessageDecompressor
+        {
+            _serviceCollection.AddTransient(typeof(IMessageDecompressor), typeof(TDecompressor));
         }
 
         public void AddDeserializer<TDeserializer>() where TDeserializer : IMessageDeserializer<T>

--- a/src/Motor.Extensions.Hosting.Consumer/Motor.Extensions.Hosting.Consumer.csproj
+++ b/src/Motor.Extensions.Hosting.Consumer/Motor.Extensions.Hosting.Consumer.csproj
@@ -6,6 +6,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\Motor.Extensions.Conversion.Abstractions\Motor.Extensions.Conversion.Abstractions.csproj" />
+        <ProjectReference Include="..\Motor.Extensions.Diagnostics.Metrics\Motor.Extensions.Diagnostics.Metrics.csproj" />
         <ProjectReference Include="..\Motor.Extensions.Hosting.Abstractions\Motor.Extensions.Hosting.Abstractions.csproj" />
         <ProjectReference Include="..\Motor.Extensions.Utilities.Abstractions\Motor.Extensions.Utilities.Abstractions.csproj" />
     </ItemGroup>

--- a/src/Motor.Extensions.Hosting.Publisher/Motor.Extensions.Hosting.Publisher.csproj
+++ b/src/Motor.Extensions.Hosting.Publisher/Motor.Extensions.Hosting.Publisher.csproj
@@ -5,8 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\Motor.Extensions.Compression.Abstractions\Motor.Extensions.Compression.Abstractions.csproj" />
         <ProjectReference Include="..\Motor.Extensions.Conversion.Abstractions\Motor.Extensions.Conversion.Abstractions.csproj" />
-        <ProjectReference Include="..\Motor.Extensions.Diagnostics.Metrics.Abstractions\Motor.Extensions.Diagnostics.Metrics.Abstractions.csproj" />
         <ProjectReference Include="..\Motor.Extensions.Diagnostics.Metrics\Motor.Extensions.Diagnostics.Metrics.csproj" />
         <ProjectReference Include="..\Motor.Extensions.Hosting.Abstractions\Motor.Extensions.Hosting.Abstractions.csproj" />
         <ProjectReference Include="..\Motor.Extensions.Utilities.Abstractions\Motor.Extensions.Utilities.Abstractions.csproj" />

--- a/src/Motor.Extensions.Hosting.Publisher/PublisherBuilder.cs
+++ b/src/Motor.Extensions.Hosting.Publisher/PublisherBuilder.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Motor.Extensions.Compression.Abstractions;
 using Motor.Extensions.Conversion.Abstractions;
 using Motor.Extensions.Hosting.Abstractions;
 
@@ -25,12 +27,18 @@ namespace Motor.Extensions.Hosting.Publisher
         public void AddPublisher<TPublisher>() where TPublisher : ITypedMessagePublisher<byte[]>
         {
             _serviceCollection.AddTransient(typeof(TPublisher));
+            _serviceCollection.AddTransient<IMessageCompressor, NoOpMessageCompressor>();
             PublisherImplType = typeof(TypedMessagePublisher<TOutput, TPublisher>);
         }
 
         public void AddSerializer<TSerializer>() where TSerializer : IMessageSerializer<TOutput>
         {
             _serviceCollection.AddTransient(typeof(IMessageSerializer<TOutput>), typeof(TSerializer));
+        }
+
+        public void AddCompressor<TCompressor>() where TCompressor : IMessageCompressor
+        {
+            _serviceCollection.Replace(ServiceDescriptor.Transient(typeof(IMessageCompressor), typeof(TCompressor)));
         }
 
         public IEnumerator<ServiceDescriptor> GetEnumerator()

--- a/src/Motor.Extensions.Hosting.Publisher/TypedMessagePublisher.cs
+++ b/src/Motor.Extensions.Hosting.Publisher/TypedMessagePublisher.cs
@@ -1,5 +1,6 @@
 using System.Threading;
 using System.Threading.Tasks;
+using Motor.Extensions.Compression.Abstractions;
 using Motor.Extensions.Conversion.Abstractions;
 using Motor.Extensions.Diagnostics.Metrics;
 using Motor.Extensions.Diagnostics.Metrics.Abstractions;
@@ -14,26 +15,38 @@ namespace Motor.Extensions.Hosting.Publisher
     {
         private readonly TPublisher _bytesMessagePublisher;
         private readonly ISummary? _messageSerialization;
+        private readonly ISummary? _messageCompression;
         private readonly IMessageSerializer<TOutput> _messageSerializer;
+        private readonly IMessageCompressor _messageCompressor;
 
         public TypedMessagePublisher(IMetricsFactory<TypedMessagePublisher<TOutput, TPublisher>>? metrics,
-            TPublisher bytesMessagePublisher, IMessageSerializer<TOutput> messageSerializer)
+            TPublisher bytesMessagePublisher, IMessageSerializer<TOutput> messageSerializer,
+            IMessageCompressor messageCompressor)
         {
             _bytesMessagePublisher = bytesMessagePublisher;
             _messageSerializer = messageSerializer;
+            _messageCompressor = messageCompressor;
             _messageSerialization =
                 metrics?.CreateSummary("message_serialization", "Message serialization duration in ms");
+            _messageCompression =
+                metrics?.CreateSummary("message_compression", "Message compression duration in ms");
         }
 
         public async Task PublishMessageAsync(MotorCloudEvent<TOutput> cloudEvent, CancellationToken token = default)
         {
-            byte[] bytes;
+            byte[] bytes, compressedBytes;
             using (new AutoObserveStopwatch(() => _messageSerialization))
             {
                 bytes = _messageSerializer.Serialize(cloudEvent.TypedData);
             }
 
-            var bytesEvent = cloudEvent.CreateNew(bytes, true);
+            using (new AutoObserveStopwatch(() => _messageCompression))
+            {
+                compressedBytes = await _messageCompressor.CompressAsync(bytes, token);
+            }
+
+            var bytesEvent = cloudEvent.CreateNew(compressedBytes, true);
+            bytesEvent.GetExtensionOrCreate(() => new CompressionTypeExtension(_messageCompressor.CompressionType));
             await _bytesMessagePublisher.PublishMessageAsync(bytesEvent, token);
         }
     }

--- a/test/Motor.Extensions.Compression.Abstractions_UnitTest/Motor.Extensions.Compression.Abstractions_UnitTest.csproj
+++ b/test/Motor.Extensions.Compression.Abstractions_UnitTest/Motor.Extensions.Compression.Abstractions_UnitTest.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net5.0</TargetFramework>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="1.3.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Motor.Extensions.Compression.Abstractions\Motor.Extensions.Compression.Abstractions.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/test/Motor.Extensions.Compression.Abstractions_UnitTest/NoOpCompressorTests.cs
+++ b/test/Motor.Extensions.Compression.Abstractions_UnitTest/NoOpCompressorTests.cs
@@ -1,0 +1,26 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Motor.Extensions.Compression.Abstractions;
+using Xunit;
+
+namespace Motor.Extensions.Compression.Abstractions_UnitTest
+{
+    public class NoOpCompressorTests
+    {
+        [Fact]
+        public async Task Compress_SomeMessage_CompressionDoesNotChangeInput()
+        {
+            var compressor = CreateCompressor();
+            var uncompressed = new byte[] { 1, 2, 3 };
+
+            var compressed = await compressor.CompressAsync(uncompressed, CancellationToken.None);
+
+            Assert.Equal(uncompressed, compressed);
+        }
+
+        private static NoOpMessageCompressor CreateCompressor()
+        {
+            return new();
+        }
+    }
+}

--- a/test/Motor.Extensions.Compression.Abstractions_UnitTest/NoOpDecompressorTests.cs
+++ b/test/Motor.Extensions.Compression.Abstractions_UnitTest/NoOpDecompressorTests.cs
@@ -1,0 +1,26 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Motor.Extensions.Compression.Abstractions;
+using Xunit;
+
+namespace Motor.Extensions.Compression.Abstractions_UnitTest
+{
+    public class NoOpDecompressorTests
+    {
+        [Fact]
+        public async Task Decompress_SomeCompressedMessage_DecompressionDoesNotChangeInput()
+        {
+            var decompressor = CreateDecompressor();
+            var compressed = new byte[] { 1, 2, 3 };
+
+            var uncompressed = await decompressor.DecompressAsync(compressed, CancellationToken.None);
+
+            Assert.Equal(compressed, uncompressed);
+        }
+
+        private static NoOpMessageDecompressor CreateDecompressor()
+        {
+            return new();
+        }
+    }
+}

--- a/test/Motor.Extensions.Compression.Gzip_UnitTest/GzipMessageCompressorTests.cs
+++ b/test/Motor.Extensions.Compression.Gzip_UnitTest/GzipMessageCompressorTests.cs
@@ -1,0 +1,42 @@
+using System.IO;
+using System.IO.Compression;
+using System.Threading;
+using System.Threading.Tasks;
+using Motor.Extensions.Compression.Gzip;
+using Xunit;
+
+namespace Motor.Extensions.Compression.Gzip_UnitTest
+{
+    public class GzipMessageCompressorTests
+    {
+        [Fact]
+        public async Task Compress_SomeUncompressedMessage_CompressedMessage()
+        {
+            var compressor = CreateCompressor();
+            var uncompressed = new byte[] { 1, 2, 3 };
+
+            var compressed = await compressor.CompressAsync(uncompressed, CancellationToken.None);
+
+            Assert.Equal(uncompressed, await DecompressInputAsync(compressed));
+        }
+
+        private static GzipMessageCompressor CreateCompressor()
+        {
+            return new();
+        }
+
+        private static async Task<byte[]> DecompressInputAsync(byte[] compressed)
+        {
+            var compressedStream = new MemoryStream(compressed);
+
+            var output = new MemoryStream();
+            //use using with explicit scope to close/flush the GZipStream before using the outputstream
+            await using (var decompressionStream = new GZipStream(compressedStream, CompressionMode.Decompress))
+            {
+                await decompressionStream.CopyToAsync(output, CancellationToken.None);
+            }
+
+            return output.ToArray();
+        }
+    }
+}

--- a/test/Motor.Extensions.Compression.Gzip_UnitTest/GzipMessageDecompressorTests.cs
+++ b/test/Motor.Extensions.Compression.Gzip_UnitTest/GzipMessageDecompressorTests.cs
@@ -1,0 +1,40 @@
+using System.IO;
+using System.IO.Compression;
+using System.Threading;
+using System.Threading.Tasks;
+using Motor.Extensions.Compression.Gzip;
+using Xunit;
+
+namespace Motor.Extensions.Compression.Gzip_UnitTest
+{
+    public class GzipMessageDecompressorTests
+    {
+        [Fact]
+        public async Task Decompress_SomeCompressedMessage_DecompressedMessage()
+        {
+            var decompressor = CreateDecompressor();
+            var decompressedInput = new byte[] { 1, 2, 3 };
+            var compressed = await CompressAsync(decompressedInput);
+
+            var decompressed = await decompressor.DecompressAsync(compressed, CancellationToken.None);
+
+            Assert.Equal(decompressedInput, decompressed);
+        }
+
+        private static GzipMessageDecompressor CreateDecompressor()
+        {
+            return new();
+        }
+
+        private static async Task<byte[]> CompressAsync(byte[] rawMessage)
+        {
+            await using var compressedStream = new MemoryStream();
+            //use using with explicit scope to close/flush the GZipStream before using the outputstream
+            await using (var zipStream = new GZipStream(compressedStream, CompressionMode.Compress))
+            {
+                await zipStream.WriteAsync(rawMessage, CancellationToken.None);
+            }
+            return compressedStream.ToArray();
+        }
+    }
+}

--- a/test/Motor.Extensions.Compression.Gzip_UnitTest/Motor.Extensions.Compression.Gzip_UnitTest.csproj
+++ b/test/Motor.Extensions.Compression.Gzip_UnitTest/Motor.Extensions.Compression.Gzip_UnitTest.csproj
@@ -3,22 +3,19 @@
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
         <IsPackable>false</IsPackable>
-        <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-        <PackageReference Include="Moq" Version="4.16.1" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
     </ItemGroup>
-
+    
     <ItemGroup>
-        <ProjectReference Include="..\..\src\Motor.Extensions.Hosting.Consumer\Motor.Extensions.Hosting.Consumer.csproj" />
-        <ProjectReference Include="..\..\src\Motor.Extensions.TestUtilities\Motor.Extensions.TestUtilities.csproj" />
+      <ProjectReference Include="..\..\src\Motor.Extensions.Compression.Gzip\Motor.Extensions.Compression.Gzip.csproj" />
     </ItemGroup>
 
 </Project>

--- a/test/Motor.Extensions.Hosting.Consumer_UnitTest/TypedConsumerServiceTests.cs
+++ b/test/Motor.Extensions.Hosting.Consumer_UnitTest/TypedConsumerServiceTests.cs
@@ -1,8 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Moq;
+using Motor.Extensions.Compression.Abstractions;
 using Motor.Extensions.Conversion.Abstractions;
 using Motor.Extensions.Hosting.Abstractions;
 using Motor.Extensions.Hosting.Consumer;
+using Motor.Extensions.TestUtilities;
 using Xunit;
 
 namespace Motor.Extensions.Hosting.Consumer_UnitTest
@@ -10,14 +16,106 @@ namespace Motor.Extensions.Hosting.Consumer_UnitTest
     public class TypedConsumerServiceTests
     {
         [Fact]
-        public void SingleMessageConsumeAsync_()
+        public async Task SingleMessageConsumeAsync_SomeEvent_PreprocessedEventAddedToQueue()
         {
-            var logger = new Mock<ILogger<TypedConsumerService<string>>>();
-            var queue = new Mock<IBackgroundTaskQueue<MotorCloudEvent<string>>>();
-            var deserializer = new Mock<IMessageDeserializer<string>>();
-            var consumer = new Mock<IMessageConsumer<string>>();
-            var consumerService =
-                new TypedConsumerService<string>(logger.Object, queue.Object, deserializer.Object, consumer.Object);
+            var inputMessage = new byte[] { 1, 2, 3 };
+            var inputEvent = MotorCloudEvent.CreateTestCloudEvent(inputMessage);
+            var fakeDecompressor = new Mock<IMessageDecompressor>();
+            var decompressedMessage = new byte[] { 4, 5, 6 };
+            fakeDecompressor.Setup(f => f.DecompressAsync(inputMessage, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(decompressedMessage);
+            fakeDecompressor.Setup(m => m.CompressionType).Returns(NoOpMessageCompressor.NoOpCompressionType);
+            var preprocessedMessage = "test";
+            var fakeDeserializer = new Mock<IMessageDeserializer<string>>();
+            fakeDeserializer.Setup(f => f.Deserialize(decompressedMessage)).Returns(preprocessedMessage);
+            var mockQueue = new Mock<IBackgroundTaskQueue<MotorCloudEvent<string>>>();
+            var fakeMessageConsumer = new Mock<IMessageConsumer<string>>();
+            fakeMessageConsumer.SetupProperty(p => p.ConsumeCallbackAsync);
+            CreateConsumerService(mockQueue.Object, fakeDeserializer.Object, fakeDecompressor.Object,
+                fakeMessageConsumer.Object);
+
+            await fakeMessageConsumer.Object.ConsumeCallbackAsync?.Invoke(inputEvent, CancellationToken.None)!;
+
+            mockQueue.Verify(m =>
+                m.QueueBackgroundWorkItem(
+                    It.Is<MotorCloudEvent<string>>(cloudEvent => cloudEvent.TypedData == preprocessedMessage)));
+        }
+
+        [Fact]
+        public async Task SingleMessageConsumeAsync_UnknownCompressionTypeInInput_InvalidInput()
+        {
+            var inputEvent = CreateMotorCloudEventWithCompressionType("unknown-compression-type");
+            var fakeDecompressor = new Mock<IMessageDecompressor>();
+            fakeDecompressor.Setup(m => m.CompressionType).Returns("other-compression-type");
+            var fakeMessageConsumer = new Mock<IMessageConsumer<string>>();
+            fakeMessageConsumer.SetupProperty(p => p.ConsumeCallbackAsync);
+            CreateConsumerService(decompressor: fakeDecompressor.Object, consumer: fakeMessageConsumer.Object);
+
+            var actual = await fakeMessageConsumer.Object.ConsumeCallbackAsync?.Invoke(inputEvent, CancellationToken.None)!;
+
+            Assert.Equal(ProcessedMessageStatus.InvalidInput, actual);
+        }
+
+        [Fact]
+        public async Task SingleMessageConsumeAsync_MultipleDecompressors_Success()
+        {
+            const string usedCompressionType = "used-compression";
+            var inputEvent = CreateMotorCloudEventWithCompressionType(usedCompressionType);
+            var unusedDecompressor = CreateDecompressor("unused-compression");
+            var usedDecompressor = CreateDecompressor(usedCompressionType);
+            var fakeMessageConsumer = new Mock<IMessageConsumer<string>>();
+            fakeMessageConsumer.SetupProperty(p => p.ConsumeCallbackAsync);
+            CreateConsumerService(
+                decompressors: new List<IMessageDecompressor> { unusedDecompressor.Object, usedDecompressor.Object },
+                consumer: fakeMessageConsumer.Object);
+
+            var actual = await fakeMessageConsumer.Object.ConsumeCallbackAsync?.Invoke(inputEvent, CancellationToken.None)!;
+
+            Assert.Equal(ProcessedMessageStatus.Success, actual);
+            usedDecompressor.Verify(m => m.DecompressAsync(inputEvent.TypedData, It.IsAny<CancellationToken>()));
+            unusedDecompressor.Verify(m => m.DecompressAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        private static MotorCloudEvent<byte[]> CreateMotorCloudEventWithCompressionType(string compressionType,
+        byte[]? inputMessage = null)
+        {
+            var cloudEvent = MotorCloudEvent.CreateTestCloudEvent(inputMessage ?? Array.Empty<byte>());
+            cloudEvent.GetExtensionOrCreate(() => new CompressionTypeExtension(compressionType));
+            return cloudEvent;
+        }
+
+        private static Mock<IMessageDecompressor> CreateDecompressor(string compressionType, byte[]? expectedInput = null,
+            byte[]? decompressedOutput = null)
+        {
+            var fakeDecompressor = new Mock<IMessageDecompressor>();
+            fakeDecompressor.Setup(f =>
+                    f.DecompressAsync(expectedInput ?? It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(decompressedOutput ?? Array.Empty<byte>());
+            fakeDecompressor.Setup(m => m.CompressionType).Returns(compressionType);
+            return fakeDecompressor;
+        }
+
+        private static void CreateConsumerService(IBackgroundTaskQueue<MotorCloudEvent<string>>? queue = null,
+            IMessageDeserializer<string>? deserializer = null,
+            IMessageDecompressor? decompressor = null,
+            IMessageConsumer<string>? consumer = null)
+        {
+            CreateConsumerService(queue, deserializer,
+                decompressor is null ? null : new List<IMessageDecompressor> { decompressor }, consumer);
+        }
+
+        private static void CreateConsumerService(IBackgroundTaskQueue<MotorCloudEvent<string>>? queue = null,
+            IMessageDeserializer<string>? deserializer = null,
+            IEnumerable<IMessageDecompressor>? decompressors = null,
+            IMessageConsumer<string>? consumer = null)
+        {
+            queue ??= Mock.Of<IBackgroundTaskQueue<MotorCloudEvent<string>>>();
+            deserializer ??= Mock.Of<IMessageDeserializer<string>>();
+            decompressors ??= new List<IMessageDecompressor> { Mock.Of<IMessageDecompressor>() };
+            consumer ??= Mock.Of<IMessageConsumer<string>>();
+            var _ = new TypedConsumerService<string>(Mock.Of<ILogger<TypedConsumerService<string>>>(), null, queue,
+                deserializer, decompressors, consumer);
         }
     }
 }

--- a/test/Motor.Extensions.Hosting.Publisher_UnitTest/Motor.Extensions.Hosting.Publisher_UnitTest.csproj
+++ b/test/Motor.Extensions.Hosting.Publisher_UnitTest/Motor.Extensions.Hosting.Publisher_UnitTest.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
         <IsPackable>false</IsPackable>
+        <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/Motor.Extensions.Hosting.Publisher_UnitTest/TypedMessagePublisherTests.cs
+++ b/test/Motor.Extensions.Hosting.Publisher_UnitTest/TypedMessagePublisherTests.cs
@@ -1,6 +1,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Moq;
+using Motor.Extensions.Compression.Abstractions;
 using Motor.Extensions.Conversion.Abstractions;
 using Motor.Extensions.Hosting.Abstractions;
 using Motor.Extensions.Hosting.Publisher;
@@ -12,36 +13,24 @@ namespace Motor.Extensions.Hosting.Publisher_UnitTest
     public class TypedMessagePublisherTests
     {
         [Fact]
-        public async Task PublishMessageAsync_MessageToSerialize_IsCalledSerializedMessage()
-        {
-            var publisher = new Mock<ITypedMessagePublisher<byte[]>>();
-            var serializer = new Mock<IMessageSerializer<string>>();
-            var typedMessagePublisher =
-                new TypedMessagePublisher<string, ITypedMessagePublisher<byte[]>>(null, publisher.Object,
-                    serializer.Object);
-            var motorEvent = MotorCloudEvent.CreateTestCloudEvent("test");
-
-            await typedMessagePublisher.PublishMessageAsync(motorEvent);
-
-            serializer.Verify(t => t.Serialize("test"), Times.Once);
-        }
-
-        [Fact]
         public async Task PublishMessageAsync_MessageToSerialize_SerializedMessageIsPublished()
         {
             var publisher = new Mock<ITypedMessagePublisher<byte[]>>();
             var serializer = new Mock<IMessageSerializer<string>>();
-            var bytes = new byte[] { 1, 2, 3, 4 };
-            serializer.Setup(t => t.Serialize(It.IsAny<string>())).Returns(bytes);
-            var typedMessagePublisher =
-                new TypedMessagePublisher<string, ITypedMessagePublisher<byte[]>>(null, publisher.Object,
-                    serializer.Object);
+            var compressor = new Mock<IMessageCompressor>();
+            var serializedBytes = new byte[] { 1, 2, 3, 4 };
+            var compressedBytes = new byte[] { 4, 3, 2, 1 };
+            serializer.Setup(t => t.Serialize(It.IsAny<string>())).Returns(serializedBytes);
+            compressor.Setup(t => t.CompressAsync(serializedBytes, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(compressedBytes);
+            compressor.SetupGet(c => c.CompressionType).Returns("someCompressionType");
+            var typedMessagePublisher = CreateTypedMessagePublisher(publisher.Object, serializer.Object, compressor.Object);
             var motorEvent = MotorCloudEvent.CreateTestCloudEvent("test");
 
             await typedMessagePublisher.PublishMessageAsync(motorEvent);
 
             publisher.Verify(t => t.PublishMessageAsync(
-                It.Is<MotorCloudEvent<byte[]>>(it => it.Data == bytes),
+                It.Is<MotorCloudEvent<byte[]>>(it => it.Data == compressedBytes),
                 It.IsAny<CancellationToken>()), Times.Once);
         }
 
@@ -49,10 +38,7 @@ namespace Motor.Extensions.Hosting.Publisher_UnitTest
         public async Task PublishMessageAsync_ContextToPassed_ContextPassed()
         {
             var publisher = new Mock<ITypedMessagePublisher<byte[]>>();
-            var serializer = new Mock<IMessageSerializer<string>>();
-            var typedMessagePublisher =
-                new TypedMessagePublisher<string, ITypedMessagePublisher<byte[]>>(null, publisher.Object,
-                    serializer.Object);
+            var typedMessagePublisher = CreateTypedMessagePublisher(publisher.Object);
             var motorEvent = MotorCloudEvent.CreateTestCloudEvent("test");
 
             await typedMessagePublisher.PublishMessageAsync(motorEvent);
@@ -60,6 +46,22 @@ namespace Motor.Extensions.Hosting.Publisher_UnitTest
             publisher.Verify(t => t.PublishMessageAsync(
                 It.Is<MotorCloudEvent<byte[]>>(it => it.Id == motorEvent.Id),
                 It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        private static TypedMessagePublisher<string, ITypedMessagePublisher<byte[]>> CreateTypedMessagePublisher(
+            ITypedMessagePublisher<byte[]>? publisher = null, IMessageSerializer<string>? serializer = null,
+            IMessageCompressor? compressor = null)
+        {
+            publisher ??= Mock.Of<ITypedMessagePublisher<byte[]>>();
+            serializer ??= Mock.Of<IMessageSerializer<string>>();
+            if (compressor is null)
+            {
+                var fakeCompressor = new Mock<IMessageCompressor>();
+                fakeCompressor.SetupGet(c => c.CompressionType).Returns("someCompressionType");
+                compressor = fakeCompressor.Object;
+            }
+            return new TypedMessagePublisher<string, ITypedMessagePublisher<byte[]>>(null, publisher, serializer,
+                compressor);
         }
     }
 }


### PR DESCRIPTION
Services can now use compression for published messages by configuring `AddGzipCompression()` on the publisher. To support decompression on consumed messages, `AddGzipDecompression()` has to be configured. At the same time, services are still able to consume uncompressed messages at all times.

This also adds a new summary for deserialization timings, together with
summaries for compression and decompression timings.

Fixes #200

Co-authored-by: Florian Grieskamp <florian.grieskamp@gdata.de>
Co-authored-by: Phillip Kemkes <phillip.kemkes@gdata.de>