### PR TITLE
Make Motor.NET forward compatible to version 0.7.0

### DIFF
--- a/shared.csproj
+++ b/shared.csproj
@@ -1,7 +1,7 @@
 <Project>
 
     <PropertyGroup>
-        <Version>0.6.14</Version>
+        <Version>0.6.15</Version>
         <LangVersion>9</LangVersion>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>CS8600;CS8602;CS8625;CS8618;CS8604;CS8601</WarningsAsErrors>


### PR DESCRIPTION
This enables services on Motor.NET 0.6 to consume messages via RabbitMQ that were produced by Motor.NET 0.7.
We want to roll this out first to make the migration to 0.7.0 easier later on. The upgrade path is then to first upgrade all services to this 0.6 version and afterwards, services can be updated to 0.7 in any order without breaking anything.
So, instead of having one big breaking update from 0.6 to 0.7, we now have to smaller updates that are non-breaking.

Part of #270