### PR TITLE
Reference shared.csproj

### DIFF
--- a/src/Motor.Extensions.Diagnostics.Queue.Abstractions/Motor.Extensions.Diagnostics.Queue.Abstractions.csproj
+++ b/src/Motor.Extensions.Diagnostics.Queue.Abstractions/Motor.Extensions.Diagnostics.Queue.Abstractions.csproj
@@ -4,4 +4,6 @@
         <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
 
+    <Import Project="$(MSBuildThisFileDirectory)../../shared.csproj" />
+
 </Project>

--- a/src/Motor.Extensions.Diagnostics.Queue.Metrics/Motor.Extensions.Diagnostics.Queue.Metrics.csproj
+++ b/src/Motor.Extensions.Diagnostics.Queue.Metrics/Motor.Extensions.Diagnostics.Queue.Metrics.csproj
@@ -15,4 +15,6 @@
       <ProjectReference Include="..\Motor.Extensions.Diagnostics.Queue.Abstractions\Motor.Extensions.Diagnostics.Queue.Abstractions.csproj" />
     </ItemGroup>
 
+    <Import Project="$(MSBuildThisFileDirectory)../../shared.csproj" />
+
 </Project>


### PR DESCRIPTION
The reference to `shared.csproj` was missing in two projects, causing these projects to be released as version `1.0.0`.