### PR TITLE
Allow multiple RabbitMQ connections with different configs

### DIFF
--- a/shared.csproj
+++ b/shared.csproj
@@ -1,7 +1,7 @@
 <Project>
 
     <PropertyGroup>
-        <Version>0.7.2</Version>
+        <Version>0.7.3</Version>
         <LangVersion>9</LangVersion>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>CS8600;CS8602;CS8625;CS8618;CS8604;CS8601</WarningsAsErrors>

--- a/src/Motor.Extensions.Hosting.RabbitMQ/Motor.Extensions.Hosting.RabbitMQ.csproj
+++ b/src/Motor.Extensions.Hosting.RabbitMQ/Motor.Extensions.Hosting.RabbitMQ.csproj
@@ -18,6 +18,12 @@
         <ProjectReference Include="..\Motor.Extensions.Utilities.Abstractions\Motor.Extensions.Utilities.Abstractions.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>$(AssemblyName)_UnitTest</_Parameter1>
+        </AssemblyAttribute>
+    </ItemGroup>
+
     <Import Project="$(MSBuildThisFileDirectory)../../shared.csproj" />
 
 </Project>

--- a/src/Motor.Extensions.Hosting.RabbitMQ/RabbitMQMessageConsumer.cs
+++ b/src/Motor.Extensions.Hosting.RabbitMQ/RabbitMQMessageConsumer.cs
@@ -18,11 +18,12 @@ namespace Motor.Extensions.Hosting.RabbitMQ
         private readonly IHostApplicationLifetime _applicationLifetime;
         private readonly IApplicationNameService _applicationNameService;
         private readonly RabbitMQConsumerOptions<T> _options;
-        private readonly IRabbitMQConnectionFactory<T> _connectionFactory;
         private readonly ILogger<RabbitMQMessageConsumer<T>> _logger;
         private bool _started;
         private IModel? _channel;
         private CancellationToken _stoppingToken;
+
+        public IRabbitMQConnectionFactory<T> ConnectionFactory { get; }
 
         public RabbitMQMessageConsumer(ILogger<RabbitMQMessageConsumer<T>> logger,
             IRabbitMQConnectionFactory<T> connectionFactory,
@@ -31,7 +32,7 @@ namespace Motor.Extensions.Hosting.RabbitMQ
             IApplicationNameService applicationNameService)
         {
             _logger = logger;
-            _connectionFactory = connectionFactory;
+            ConnectionFactory = connectionFactory;
             _options = config.Value;
             _applicationLifetime = applicationLifetime;
             _applicationNameService = applicationNameService;
@@ -53,7 +54,7 @@ namespace Motor.Extensions.Hosting.RabbitMQ
         {
             ThrowIfNoCallbackConfigured();
             ThrowIfConsumerAlreadyStarted();
-            _channel = _connectionFactory.CurrentChannel;
+            _channel = ConnectionFactory.CurrentChannel;
             ConfigureChannel();
             DeclareQueue();
             StartConsumerOnChannel();
@@ -63,7 +64,7 @@ namespace Motor.Extensions.Hosting.RabbitMQ
         public Task StopAsync(CancellationToken token = default)
         {
             _started = false;
-            _connectionFactory.Dispose();
+            ConnectionFactory.Dispose();
             return Task.CompletedTask;
         }
 

--- a/src/Motor.Extensions.Hosting.RabbitMQ/RabbitMQMessageConsumer.cs
+++ b/src/Motor.Extensions.Hosting.RabbitMQ/RabbitMQMessageConsumer.cs
@@ -23,7 +23,7 @@ namespace Motor.Extensions.Hosting.RabbitMQ
         private IModel? _channel;
         private CancellationToken _stoppingToken;
 
-        public IRabbitMQConnectionFactory<T> ConnectionFactory { get; }
+        internal IRabbitMQConnectionFactory<T> ConnectionFactory { get; }
 
         public RabbitMQMessageConsumer(ILogger<RabbitMQMessageConsumer<T>> logger,
             IRabbitMQConnectionFactory<T> connectionFactory,

--- a/src/Motor.Extensions.Hosting.RabbitMQ/RabbitMQMessageHostBuilderExtensions.cs
+++ b/src/Motor.Extensions.Hosting.RabbitMQ/RabbitMQMessageHostBuilderExtensions.cs
@@ -2,9 +2,13 @@ using CloudNative.CloudEvents;
 using CloudNative.CloudEvents.SystemTextJson;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using MSOptions = Microsoft.Extensions.Options.Options;
 using Microsoft.Extensions.Options;
 using Motor.Extensions.Diagnostics.Queue.Abstractions;
 using Motor.Extensions.Hosting.Abstractions;
+using Motor.Extensions.Hosting.CloudEvents;
 using Motor.Extensions.Hosting.RabbitMQ.Options;
 
 namespace Motor.Extensions.Hosting.RabbitMQ
@@ -14,11 +18,17 @@ namespace Motor.Extensions.Hosting.RabbitMQ
         public static void AddRabbitMQWithConfig<T>(this IConsumerBuilder<T> builder, IConfiguration config) where T : notnull
         {
             builder.AddTransient<CloudEventFormatter, JsonEventFormatter>();
-            builder.Configure<RabbitMQConsumerOptions<T>>(config);
-            builder.AddSingleton(sp =>
-                RabbitMQConnectionFactory<T>.From(sp.GetRequiredService<IOptions<RabbitMQConsumerOptions<T>>>().Value));
-            builder.AddConsumer<RabbitMQMessageConsumer<T>>();
-            builder.AddSingleton<IQueueMonitor, RabbitMQQueueMonitor<T>>();
+            var consumerOptions = new RabbitMQConsumerOptions<T>();
+            config.Bind(consumerOptions);
+            var connectionFactory = RabbitMQConnectionFactory<T>.From(consumerOptions);
+            builder.AddConsumer(sp => new RabbitMQMessageConsumer<T>(
+                sp.GetRequiredService<ILogger<RabbitMQMessageConsumer<T>>>(), connectionFactory,
+                MSOptions.Create(consumerOptions),
+                sp.GetRequiredService<IHostApplicationLifetime>(),
+                sp.GetRequiredService<IApplicationNameService>()));
+            builder.AddSingleton<IQueueMonitor>(sp =>
+                new RabbitMQQueueMonitor<T>(sp.GetRequiredService<ILogger<RabbitMQQueueMonitor<T>>>(),
+                    MSOptions.Create(consumerOptions), connectionFactory));
         }
 
         public static void AddRabbitMQ<T>(this IConsumerBuilder<T> builder, string configSection = "RabbitMQConsumer") where T : notnull
@@ -30,10 +40,13 @@ namespace Motor.Extensions.Hosting.RabbitMQ
         {
             builder.AddTransient<CloudEventFormatter, JsonEventFormatter>();
             builder.Configure<RabbitMQPublisherOptions<T>>(config);
-            builder.AddSingleton(sp =>
-                RabbitMQConnectionFactory<T>.From(sp.GetRequiredService<IOptions<RabbitMQPublisherOptions<T>>>()
-                    .Value));
-            builder.AddPublisher<RabbitMQMessagePublisher<T>>();
+            var publisherOptions = new RabbitMQPublisherOptions<T>();
+            config.Bind(publisherOptions);
+            var connectionFactory = RabbitMQConnectionFactory<T>.From(publisherOptions);
+            builder.AddPublisher(sp
+             => new RabbitMQMessagePublisher<T>(connectionFactory,
+                 MSOptions.Create(publisherOptions),
+                 sp.GetRequiredService<CloudEventFormatter>()));
         }
 
         public static void AddRabbitMQ<T>(this IPublisherBuilder<T> builder, string configSection = "RabbitMQPublisher") where T : notnull

--- a/src/Motor.Extensions.Hosting.RabbitMQ/RabbitMQMessageHostBuilderExtensions.cs
+++ b/src/Motor.Extensions.Hosting.RabbitMQ/RabbitMQMessageHostBuilderExtensions.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using MSOptions = Microsoft.Extensions.Options.Options;
-using Microsoft.Extensions.Options;
 using Motor.Extensions.Diagnostics.Queue.Abstractions;
 using Motor.Extensions.Hosting.Abstractions;
 using Motor.Extensions.Hosting.CloudEvents;

--- a/src/Motor.Extensions.Hosting.RabbitMQ/RabbitMQMessageHostBuilderExtensions.cs
+++ b/src/Motor.Extensions.Hosting.RabbitMQ/RabbitMQMessageHostBuilderExtensions.cs
@@ -4,11 +4,11 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using MSOptions = Microsoft.Extensions.Options.Options;
 using Motor.Extensions.Diagnostics.Queue.Abstractions;
 using Motor.Extensions.Hosting.Abstractions;
 using Motor.Extensions.Hosting.CloudEvents;
 using Motor.Extensions.Hosting.RabbitMQ.Options;
+using MSOptions = Microsoft.Extensions.Options.Options;
 
 namespace Motor.Extensions.Hosting.RabbitMQ
 {
@@ -21,7 +21,8 @@ namespace Motor.Extensions.Hosting.RabbitMQ
             config.Bind(consumerOptions);
             var connectionFactory = RabbitMQConnectionFactory<T>.From(consumerOptions);
             builder.AddConsumer(sp => new RabbitMQMessageConsumer<T>(
-                sp.GetRequiredService<ILogger<RabbitMQMessageConsumer<T>>>(), connectionFactory,
+                sp.GetRequiredService<ILogger<RabbitMQMessageConsumer<T>>>(),
+                connectionFactory,
                 MSOptions.Create(consumerOptions),
                 sp.GetRequiredService<IHostApplicationLifetime>(),
                 sp.GetRequiredService<IApplicationNameService>()));

--- a/src/Motor.Extensions.Hosting.RabbitMQ/RabbitMQMessagePublisher.cs
+++ b/src/Motor.Extensions.Hosting.RabbitMQ/RabbitMQMessagePublisher.cs
@@ -18,7 +18,7 @@ namespace Motor.Extensions.Hosting.RabbitMQ
         private IModel? _channel;
         private bool _connected;
 
-        public IRabbitMQConnectionFactory<T> ConnectionFactory { get; }
+        internal IRabbitMQConnectionFactory<T> ConnectionFactory { get; }
 
         public RabbitMQMessagePublisher(
             IRabbitMQConnectionFactory<T> connectionFactory,

--- a/src/Motor.Extensions.Hosting.RabbitMQ/RabbitMQMessagePublisher.cs
+++ b/src/Motor.Extensions.Hosting.RabbitMQ/RabbitMQMessagePublisher.cs
@@ -15,9 +15,10 @@ namespace Motor.Extensions.Hosting.RabbitMQ
     {
         private readonly CloudEventFormatter _cloudEventFormatter;
         private readonly RabbitMQPublisherOptions<T> _options;
-        private readonly IRabbitMQConnectionFactory<T> _connectionFactory;
         private IModel? _channel;
         private bool _connected;
+
+        public IRabbitMQConnectionFactory<T> ConnectionFactory { get; }
 
         public RabbitMQMessagePublisher(
             IRabbitMQConnectionFactory<T> connectionFactory,
@@ -25,7 +26,7 @@ namespace Motor.Extensions.Hosting.RabbitMQ
             CloudEventFormatter cloudEventFormatter
         )
         {
-            _connectionFactory = connectionFactory;
+            ConnectionFactory = connectionFactory;
             _cloudEventFormatter = cloudEventFormatter;
             _options = config.Value;
         }
@@ -60,7 +61,7 @@ namespace Motor.Extensions.Hosting.RabbitMQ
 
         private Task StartAsync()
         {
-            _channel = _connectionFactory.CurrentChannel;
+            _channel = ConnectionFactory.CurrentChannel;
             _connected = true;
             return Task.CompletedTask;
         }

--- a/test/Motor.Extensions.Hosting.RabbitMQ_UnitTest/RabbitMQMessageHostBuilderExtensionsTests.cs
+++ b/test/Motor.Extensions.Hosting.RabbitMQ_UnitTest/RabbitMQMessageHostBuilderExtensionsTests.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Motor.Extensions.Conversion.Abstractions;
+using Motor.Extensions.Hosting.Abstractions;
+using Motor.Extensions.Hosting.CloudEvents;
+using Motor.Extensions.Hosting.Consumer;
+using Motor.Extensions.Hosting.Publisher;
+using Motor.Extensions.Hosting.RabbitMQ;
+using Motor.Extensions.Utilities;
+using Motor.Extensions.Utilities.Abstractions;
+using Xunit;
+
+namespace Motor.Extensions.Hosting.RabbitMQ_UnitTest
+{
+    public class RabbitMQMessageHostBuilderExtensionsTests
+    {
+        private static IConfiguration GetConfigWithVHost(string vHost)
+        {
+            var configDict = new Dictionary<string, string>
+            {
+                { "Host", "localhost" },
+                { "User", "guest" },
+                { "Password", "guest" },
+                { "Queue:Name", "Test" },
+                { "VirtualHost", vHost },
+                { "PublishingTarget:RoutingKey", "routing.key" },
+                { "PublishingTarget:Exchange", "amq.topic" }
+            };
+            return new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
+        }
+
+        private static IMotorHostBuilder GetHostBuilder()
+        {
+            return MotorHost.CreateDefaultBuilder()
+                .ConfigureSingleOutputService<string, string>()
+                .ConfigureServices((_, services) =>
+                {
+                    services.AddTransient(_ =>
+                    {
+                        var mock = new Mock<IApplicationNameService>();
+                        mock.Setup(t => t.GetVersion()).Returns("test");
+                        mock.Setup(t => t.GetLibVersion()).Returns("test");
+                        mock.Setup(t => t.GetSource()).Returns(new Uri("motor://test"));
+                        return mock.Object;
+                    });
+                });
+        }
+
+        [Fact]
+        public void AddRabbitMQWithConfig_ConsumersWithDifferentConfigAdded_ConsumersWithDifferentConfigPresent()
+        {
+            var consumers = GetHostBuilder()
+                .ConfigureConsumer<string>((_, builder) =>
+                {
+                    builder.AddRabbitMQWithConfig(GetConfigWithVHost("Host1"));
+                    builder.AddDeserializer<StringDeserializer>();
+                })
+                .ConfigureConsumer<string>((_, builder) =>
+                {
+                    builder.AddRabbitMQWithConfig(GetConfigWithVHost("Host2"));
+                    builder.AddDeserializer<StringDeserializer>();
+                })
+                .Build().Services
+                .GetServices<IMessageConsumer<string>>().ToList();
+
+            Assert.Contains(consumers, c => ((RabbitMQMessageConsumer<string>)c).ConnectionFactory.VirtualHost == "Host1");
+            Assert.Contains(consumers, c => ((RabbitMQMessageConsumer<string>)c).ConnectionFactory.VirtualHost == "Host2");
+        }
+
+        [Fact]
+        public void AddRabbitMQWithConfig_PublishersWithDifferentConfigAdded_PublishersWithDifferentConfigPresent()
+        {
+            var publishers = GetHostBuilder()
+                .ConfigurePublisher<string>((_, builder) =>
+                {
+                    builder.AddRabbitMQWithConfig(GetConfigWithVHost("Host1"));
+                    builder.AddSerializer<StringSerializer>();
+                })
+                .ConfigurePublisher<string>((_, builder) =>
+                {
+                    builder.AddRabbitMQWithConfig(GetConfigWithVHost("Host2"));
+                    builder.AddSerializer<StringSerializer>();
+                })
+                .Build().Services
+                .GetServices<RabbitMQMessagePublisher<string>>().ToList();
+
+            Assert.Contains(publishers, c => c.ConnectionFactory.VirtualHost == "Host1");
+            Assert.Contains(publishers, c => c.ConnectionFactory.VirtualHost == "Host2");
+        }
+
+        [Fact]
+        public void AddRabbitMQWithConfig_ConsumerAndPublisherWithDifferentConfigAdded_ConsumerAndPublisherWithDifferentConfigPresent()
+        {
+            var host = GetHostBuilder()
+                .ConfigureConsumer<string>((_, builder) =>
+                {
+                    builder.AddRabbitMQWithConfig(GetConfigWithVHost("Host1"));
+                    builder.AddDeserializer<StringDeserializer>();
+                })
+                .ConfigurePublisher<string>((_, builder) =>
+                {
+                    builder.AddRabbitMQWithConfig(GetConfigWithVHost("Host2"));
+                    builder.AddSerializer<StringSerializer>();
+                })
+                .Build();
+
+            var consumers = host.Services.GetServices<IMessageConsumer<string>>().ToList();
+            var publishers = host.Services.GetServices<RabbitMQMessagePublisher<string>>().ToList();
+
+            Assert.Contains(consumers, c => ((RabbitMQMessageConsumer<string>)c).ConnectionFactory.VirtualHost == "Host1");
+            Assert.Contains(publishers, c => c.ConnectionFactory.VirtualHost == "Host2");
+        }
+
+        private class StringSerializer : IMessageSerializer<string>
+        {
+            public byte[] Serialize(string message)
+            {
+                return Encoding.UTF8.GetBytes(message);
+            }
+        }
+
+        private class StringDeserializer : IMessageDeserializer<string>
+        {
+            public string Deserialize(byte[] message)
+            {
+                return Encoding.UTF8.GetString(message);
+            }
+
+        }
+    }
+}

--- a/test/Motor.Extensions.Hosting.RabbitMQ_UnitTest/RabbitMQMessageHostBuilderExtensionsTests.cs
+++ b/test/Motor.Extensions.Hosting.RabbitMQ_UnitTest/RabbitMQMessageHostBuilderExtensionsTests.cs
@@ -19,21 +19,6 @@ namespace Motor.Extensions.Hosting.RabbitMQ_UnitTest
 {
     public class RabbitMQMessageHostBuilderExtensionsTests
     {
-        private static IConfiguration GetConfigWithVHost(string vHost)
-        {
-            var configDict = new Dictionary<string, string>
-            {
-                { "Host", "localhost" },
-                { "User", "guest" },
-                { "Password", "guest" },
-                { "Queue:Name", "Test" },
-                { "VirtualHost", vHost },
-                { "PublishingTarget:RoutingKey", "routing.key" },
-                { "PublishingTarget:Exchange", "amq.topic" }
-            };
-            return new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
-        }
-
         private static IMotorHostBuilder GetHostBuilder()
         {
             return MotorHost.CreateDefaultBuilder()
@@ -114,6 +99,21 @@ namespace Motor.Extensions.Hosting.RabbitMQ_UnitTest
 
             Assert.Contains(consumers, c => ((RabbitMQMessageConsumer<string>)c).ConnectionFactory.VirtualHost == "Host1");
             Assert.Contains(publishers, c => c.ConnectionFactory.VirtualHost == "Host2");
+        }
+
+        private static IConfiguration GetConfigWithVHost(string vHost)
+        {
+            var configDict = new Dictionary<string, string>
+            {
+                { "Host", "localhost" },
+                { "User", "guest" },
+                { "Password", "guest" },
+                { "Queue:Name", "Test" },
+                { "VirtualHost", vHost },
+                { "PublishingTarget:RoutingKey", "routing.key" },
+                { "PublishingTarget:Exchange", "amq.topic" }
+            };
+            return new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
         }
 
         private class StringSerializer : IMessageSerializer<string>


### PR DESCRIPTION
With previous versions, we ran into an issue, where the same RabbitMQ configuration was used for every consumer/publisher of the same type. With this change, it will become possible to add multiple consumers and/or publishers of the same type with different configurations (e.g. routing keys).