### PR TITLE
Publish plain TypedData instead of base64 encoded byte arrays

### DIFF
--- a/shared.csproj
+++ b/shared.csproj
@@ -1,7 +1,7 @@
 <Project>
 
     <PropertyGroup>
-        <Version>0.7.3</Version>
+        <Version>0.7.4</Version>
         <LangVersion>9</LangVersion>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>CS8600;CS8602;CS8625;CS8618;CS8604;CS8601</WarningsAsErrors>

--- a/src/Motor.Extensions.Hosting.RabbitMQ/RabbitMQMessagePublisher.cs
+++ b/src/Motor.Extensions.Hosting.RabbitMQ/RabbitMQMessagePublisher.cs
@@ -55,8 +55,7 @@ namespace Motor.Extensions.Hosting.RabbitMQ
                 exchange = _options.PublishingTarget.Exchange;
             }
 
-            _channel.BasicPublish(exchange, routingKey, true, properties,
-                _cloudEventFormatter.EncodeBinaryModeEventData(motorCloudEvent.ConvertToCloudEvent()));
+            _channel.BasicPublish(exchange, routingKey, true, properties, motorCloudEvent.TypedData);
         }
 
         private Task StartAsync()


### PR DESCRIPTION
This caused the body of the messages to be a base64 encoded bytearray instead of the string interpretation of the bytearray. Also the incorrect RabbitMQ binding were used as they were taken from the incoming CloudEvent.