### PR TITLE
Fix RequireValid attribute to catch null values in collection properties

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "5.0",
+    "rollForward": "latestMajor",
+    "allowPrerelease": true
+  }
+}

--- a/shared.csproj
+++ b/shared.csproj
@@ -1,7 +1,7 @@
 <Project>
 
     <PropertyGroup>
-        <Version>0.8.1</Version>
+        <Version>0.8.2</Version>
         <LangVersion>9</LangVersion>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>CS8600;CS8602;CS8625;CS8618;CS8604;CS8601</WarningsAsErrors>

--- a/src/Motor.Extensions.Hosting.RabbitMQ/Validation/RequireValidAttribute.cs
+++ b/src/Motor.Extensions.Hosting.RabbitMQ/Validation/RequireValidAttribute.cs
@@ -28,12 +28,17 @@ namespace Motor.Extensions.Hosting.RabbitMQ.Validation
             return ValidationResult.Success;
         }
 
-        private ValidationResult? ValidateObject(object value, ValidationContext validationContext)
+        private static ValidationResult? ValidateObject(object? value, ValidationContext validationContext)
         {
+            if (value == null)
+            {
+                return new ValidationResult("Value may no be null");
+            }
+
             try
             {
-                Validator.ValidateObject(value,
-                    new ValidationContext(value, validationContext, validationContext.Items), true);
+                var innerContext = new ValidationContext(value, validationContext, validationContext.Items);
+                Validator.ValidateObject(value, innerContext, true);
             }
             catch (ValidationException e)
             {

--- a/test/Motor.Extensions.Hosting.RabbitMQ_UnitTest/Validation/RequireValidAttributeTests.cs
+++ b/test/Motor.Extensions.Hosting.RabbitMQ_UnitTest/Validation/RequireValidAttributeTests.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -20,75 +21,82 @@ namespace Motor.Extensions.Hosting.RabbitMQ_UnitTest.Validation
         [MemberData(nameof(InvalidObjects))]
         public void Validate_InValidObject_ValidationException(Wrapper toValidate)
         {
-            if (toValidate == null)
-            {
-                Assert.Throws<ArgumentNullException>(
-                    () => ValidateObject(toValidate, new ValidationContext(toValidate)));
-            }
-            else
-            {
-                Assert.Throws<ValidationException>(() => ValidateObject(toValidate, new ValidationContext(toValidate)));
-            }
+            Assert.Throws<ValidationException>(() => ValidateObject(toValidate, new ValidationContext(toValidate)));
         }
 
         public record Nested
         {
             [Required(AllowEmptyStrings = false)]
-            public string Greeting { get; init; }
+            public string? Greeting { get; init; }
         }
 
         public record Wrapper
         {
             [RequireValid]
-            public Nested Nested { get; init; }
+            public Nested? Nested { get; init; }
 
             [RequireValid]
-            public List<Nested> NestedList { get; init; } = new();
+            public List<Nested?> NestedList { get; init; } = new();
 
             [RequireValid]
-            public Nested[] NestedArray { get; init; } = Array.Empty<Nested>();
+            public Nested?[] NestedArray { get; init; } = Array.Empty<Nested>();
 
             [RequireValid]
-            public ICollection<Nested> NestedCollection { get; init; } = new List<Nested>();
+            public ICollection<Nested?> NestedCollection { get; init; } = new List<Nested?>();
         }
 
         public static IEnumerable<object[]> InvalidObjects => new[]
         {
-            new[] {null as Wrapper},
-            new[] {new Wrapper()},
-            new[] {new Wrapper {Nested = new Nested {Greeting = "Hello"}, NestedArray = null}},
-            new[] {new Wrapper {Nested = new Nested {Greeting = "Hello"}, NestedList = null}},
-            new[] {new Wrapper {Nested = new Nested {Greeting = "Hello"}, NestedCollection = null}},
-            new[] {new Wrapper {Nested = new Nested {Greeting = "Hello"}, NestedArray = new[] {new Nested()}}},
-            new[] {new Wrapper {Nested = new Nested {Greeting = "Hello"}, NestedList = new List<Nested> {new()}}},
-            new[] {new Wrapper {Nested = new Nested {Greeting = "Hello"}, NestedCollection = new List<Nested> {new()}}},
+            new[] { new Wrapper() },
+            new[] { new Wrapper { Nested = new Nested { Greeting = "Hello" }, NestedArray = null } },
+            new[] { new Wrapper { Nested = new Nested { Greeting = "Hello" }, NestedList = null } },
+            new[] { new Wrapper { Nested = new Nested { Greeting = "Hello" }, NestedCollection = null } },
+            new[] { new Wrapper { Nested = new Nested { Greeting = "Hello" }, NestedArray = new[] { new Nested() } } },
+            new[]
+            {
+                new Wrapper { Nested = new Nested { Greeting = "Hello" }, NestedList = new List<Nested?> { new() } }
+            },
+            new[]
+            {
+                new Wrapper
+                {
+                    Nested = new Nested { Greeting = "Hello" }, NestedCollection = new List<Nested?> { new() }
+                }
+            },
+            new[]
+            {
+                new Wrapper
+                {
+                    Nested = new Nested { Greeting = "Hello" }, NestedCollection = new List<Nested?> { new(), null }
+                }
+            },
         };
 
         public static IEnumerable<object[]> ValidObjects => new[]
         {
-            new[] {new Wrapper {Nested = new Nested {Greeting = "Hello"}}},
+            new[] { new Wrapper { Nested = new Nested { Greeting = "Hello" } } },
             new[]
             {
                 new Wrapper
                 {
-                    Nested = new Nested {Greeting = "Hello"},
-                    NestedArray = new[] {new Nested {Greeting = "Hello"}}
+                    Nested = new Nested { Greeting = "Hello" },
+                    NestedArray = new[] { new Nested { Greeting = "Hello" } }
                 }
             },
             new[]
             {
                 new Wrapper
                 {
-                    Nested = new Nested {Greeting = "Hello"},
-                    NestedList = new List<Nested> {new() {Greeting = "Hello"}}
+                    Nested = new Nested { Greeting = "Hello" },
+                    NestedList = new List<Nested?> { new() { Greeting = "Hello" } }
                 }
             },
             new[]
             {
                 new Wrapper
                 {
-                    Nested = new Nested {Greeting = "Hello"},
-                    NestedCollection = new List<Nested> {new() {Greeting = "Hello"}}
+                    Nested = new Nested { Greeting = "Hello" },
+                    NestedCollection = new List<Nested?> { new() { Greeting = "Hello" } }
                 }
             },
         };


### PR DESCRIPTION
Previously only null value collections would have been detected but a collection containing a null value raised an exception when the inner validation context got created