### PR TITLE
Ignore content encoding in bridge service

### DIFF
--- a/shared.csproj
+++ b/shared.csproj
@@ -1,7 +1,7 @@
 <Project>
 
     <PropertyGroup>
-        <Version>0.8.2</Version>
+        <Version>0.8.3</Version>
         <LangVersion>9</LangVersion>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>CS8600;CS8602;CS8625;CS8618;CS8604;CS8601</WarningsAsErrors>

--- a/src/Motor.Extensions.ContentEncoding.Abstractions/ContentEncodingOptions.cs
+++ b/src/Motor.Extensions.ContentEncoding.Abstractions/ContentEncodingOptions.cs
@@ -1,0 +1,7 @@
+namespace Motor.Extensions.ContentEncoding.Abstractions
+{
+    public record ContentEncodingOptions
+    {
+        public bool IgnoreEncoding { get; init; }
+    }
+}

--- a/src/Motor.Extensions.Hosting.Bridge/appsettings.json
+++ b/src/Motor.Extensions.Hosting.Bridge/appsettings.json
@@ -2,6 +2,9 @@
   "ApplicationName": {
     "FullName": ""
   },
+  "ContentEncoding": {
+    "IgnoreEncoding": true
+  },
   "ConsumerType": "RabbitMQ",
   "Consumer": {},
   "PublisherType": "RabbitMQ",

--- a/src/Motor.Extensions.Utilities/MotorHost.cs
+++ b/src/Motor.Extensions.Utilities/MotorHost.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
+using Motor.Extensions.ContentEncoding.Abstractions;
 using Motor.Extensions.Diagnostics.Logging;
 using Motor.Extensions.Diagnostics.Metrics;
 using Motor.Extensions.Diagnostics.Telemetry;
@@ -22,7 +23,9 @@ namespace Motor.Extensions.Utilities
         }
 
         public static IMotorHostBuilder CreateDefaultBuilder(Assembly? assembly = null,
-            bool enableConfigureWebDefaults = true, string applicationName = "ApplicationName")
+            bool enableConfigureWebDefaults = true,
+            string applicationName = "ApplicationName",
+            string contentEncoding = "ContentEncoding")
         {
             assembly ??= Assembly.GetCallingAssembly();
 
@@ -33,6 +36,7 @@ namespace Motor.Extensions.Utilities
                 .ConfigureServices((ctx, collection) =>
                 {
                     collection.Configure<DefaultApplicationNameOptions>(ctx.Configuration.GetSection(applicationName));
+                    collection.Configure<ContentEncodingOptions>(ctx.Configuration.GetSection(contentEncoding));
                     collection.AddTransient<IApplicationNameService>(provider =>
                     {
                         var options = provider.GetRequiredService<IOptions<DefaultApplicationNameOptions>>();

--- a/test/Motor.Extensions.Hosting.CloudEvents_UnitTest/MotorCloudEventTests.cs
+++ b/test/Motor.Extensions.Hosting.CloudEvents_UnitTest/MotorCloudEventTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Moq;
+using Motor.Extensions.ContentEncoding.Abstractions;
 using Motor.Extensions.Hosting.CloudEvents;
 using Xunit;
 
@@ -48,6 +49,19 @@ namespace Motor.Extensions.Hosting.CloudEvents_UnitTest
 
             Assert.Equal(nameof(String), oldEvent.Type);
             Assert.Equal(nameof(String), newEvent.Type);
+        }
+
+        [Fact]
+        public void CreateNew_OldEventHasContentEncoding_NewEventHasSameContentEncoding()
+        {
+            var oldEvent =
+                new MotorCloudEvent<string>(GetApplicationNameService(), " ", new Uri("test://non"));
+            oldEvent.SetEncoding("some-encoding");
+            var expectedData = new List<string>();
+
+            var newEvent = oldEvent.CreateNew(expectedData);
+
+            Assert.Equal(oldEvent.GetEncoding(), newEvent.GetEncoding());
         }
 
         [Fact]


### PR DESCRIPTION
Up to this point, `ContentEncoding` breaks the Bridge service.

Encodings must be added on the consumer side within the HostBuilder and by default, only the `NoOpMessageDecoder` is added. Therefore, Bridge services cannot deal with other encodings. However, since it is not necessary for a Bridge to decode and encode a message at all, this PR introduces an option to ignore `ContentEncoding` altogether.

If this option is set, ...
- the NoOpMessageDecoder is used to decode messages
- the NoOpMessageEncoder is used to encode messages
- the `ContentEncoding` field of published messages is assigned the same value as seen on the consumed message.