### PR TITLE
Set back version to 0.8.2 as there was no release yet

### DIFF
--- a/shared.csproj
+++ b/shared.csproj
@@ -1,7 +1,7 @@
 <Project>
 
     <PropertyGroup>
-        <Version>0.8.3</Version>
+        <Version>0.8.2</Version>
         <LangVersion>9</LangVersion>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>CS8600;CS8602;CS8625;CS8618;CS8604;CS8601</WarningsAsErrors>


### PR DESCRIPTION
In the [previous PR](https://github.com/GDATASoftwareAG/motornet/pull/345) I increased the version from 0.8.2 to 0.8.3. However, 0.8.2 was never released, so the version does not need to be increased just yet. I will release both features together as 0.8.2.