### PR TITLE
Publish symbols

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,9 +2,9 @@ name: .NET
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ["master"]
   pull_request:
-    branches: [ "master" ]
+    branches: ["master"]
   release:
     types:
       - published
@@ -17,42 +17,42 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: "6.0.102"
-    - name: check format
-      run: dotnet format --severity error --verify-no-changes ./Motor.NET.sln
+      - uses: actions/checkout@v2
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "6.0.102"
+      - name: check format
+        run: dotnet format --severity error --verify-no-changes ./Motor.NET.sln
 
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 6.0.x
-    - name: Install dependencies
-      run: dotnet restore Motor.NET.sln
-    - name: Build
-      run: dotnet build --configuration Release --no-restore Motor.NET.sln
-    - name: Test
-      run: dotnet test --no-restore Motor.NET.sln
-    - name: Pack
-      run: dotnet pack -v minimal -c Release --no-restore -o ./artifacts Motor.NET.sln
-    - name: Publish Bridge
-      run: dotnet publish -v minimal -c Release --no-restore -o ./artifacts-bridge ./src/Motor.Extensions.Hosting.Bridge/Motor.Extensions.Hosting.Bridge.csproj
-    - name: Upload Artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: artifacts
-        path: ./artifacts/*.nupkg
-    - name: Upload Artifact Bridge
-      uses: actions/upload-artifact@v2
-      with:
-        name: artifacts-bridge
-        path: ./artifacts-bridge/*
+      - uses: actions/checkout@v2
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
+      - name: Install dependencies
+        run: dotnet restore Motor.NET.sln
+      - name: Build
+        run: dotnet build --configuration Release --no-restore Motor.NET.sln
+      - name: Test
+        run: dotnet test --no-restore Motor.NET.sln
+      - name: Pack
+        run: dotnet pack -v minimal -c Release --no-restore -o ./artifacts Motor.NET.sln
+      - name: Publish Bridge
+        run: dotnet publish -v minimal -c Release --no-restore -o ./artifacts-bridge ./src/Motor.Extensions.Hosting.Bridge/Motor.Extensions.Hosting.Bridge.csproj
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: artifacts
+          path: ./artifacts/*.nupkg
+      - name: Upload Artifact Bridge
+        uses: actions/upload-artifact@v2
+        with:
+          name: artifacts-bridge
+          path: ./artifacts-bridge/*
 
   #code-ql:
   #  runs-on: ubuntu-latest
@@ -87,7 +87,7 @@ jobs:
         with:
           dotnet-version: 6.0.x
       - name: Push to NuGet Feed
-        run: dotnet nuget push './artifacts/*.nupkg' --skip-duplicate --source $NUGET_FEED --api-key $NUGET_KEY
+        run: dotnet nuget push './artifacts/*nupkg' --skip-duplicate --source $NUGET_FEED --api-key $NUGET_KEY
 
   build-bridge:
     needs: build

--- a/shared.csproj
+++ b/shared.csproj
@@ -1,7 +1,7 @@
 <Project>
 
     <PropertyGroup>
-        <Version>0.9.8</Version>
+        <Version>0.9.9</Version>
         <LangVersion>10</LangVersion>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>CS8600;CS8602;CS8625;CS8618;CS8604;CS8601</WarningsAsErrors>

--- a/shared.csproj
+++ b/shared.csproj
@@ -9,6 +9,7 @@
 
     <PropertyGroup>
         <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
     </PropertyGroup>
 

--- a/shared.csproj
+++ b/shared.csproj
@@ -28,4 +28,8 @@
         <None Include="../../rsc/Icon_Motor_NET_128.png" Pack="true" PackagePath="/" />
     </ItemGroup>
 
+    <ItemGroup>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Currently, there are no symbols available for Motor on Nuget. This makes debugging harder, as it is not possible to step into the Motor code.

This PR should fix that, as the *.snupkg gets created for each *.nupkg.