### PR TITLE
Bump package version in shared.csproj

### DIFF
--- a/shared.csproj
+++ b/shared.csproj
@@ -1,7 +1,7 @@
 <Project>
 
     <PropertyGroup>
-        <Version>0.10.2</Version>
+        <Version>0.10.5</Version>
         <LangVersion>10</LangVersion>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>CS8600;CS8602;CS8625;CS8618;CS8604;CS8601</WarningsAsErrors>


### PR DESCRIPTION
We previously had problems with releasing due to a not up-to-date testcontainers version. Now, the push to NuGet failed, because we forgot to bump the package version in the `shared.csproj`. This PR should fix that.