### PR TITLE
Let all services report message_processing timings

### DIFF
--- a/shared.csproj
+++ b/shared.csproj
@@ -1,7 +1,7 @@
 <Project>
 
     <PropertyGroup>
-        <Version>0.12.0</Version>
+        <Version>0.13.0</Version>
         <LangVersion>11</LangVersion>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>CS8600;CS8602;CS8625;CS8618;CS8604;CS8601</WarningsAsErrors>

--- a/src/Motor.Extensions.Hosting/MultiOutputServiceAdapter.cs
+++ b/src/Motor.Extensions.Hosting/MultiOutputServiceAdapter.cs
@@ -2,11 +2,8 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Motor.Extensions.Diagnostics.Metrics;
-using Motor.Extensions.Diagnostics.Metrics.Abstractions;
 using Motor.Extensions.Hosting.Abstractions;
 using Motor.Extensions.Hosting.CloudEvents;
-using Prometheus.Client;
 
 namespace Motor.Extensions.Hosting;
 
@@ -16,18 +13,15 @@ public class MultiOutputServiceAdapter<TInput, TOutput> : INoOutputService<TInpu
 {
     private readonly IMultiOutputService<TInput, TOutput> _converter;
     private readonly ILogger<SingleOutputServiceAdapter<TInput, TOutput>> _logger;
-    private readonly ISummary? _messageProcessing;
     private readonly ITypedMessagePublisher<TOutput> _publisher;
 
     public MultiOutputServiceAdapter(ILogger<SingleOutputServiceAdapter<TInput, TOutput>> logger,
-        IMetricsFactory<SingleOutputServiceAdapter<TInput, TOutput>>? metrics,
         IMultiOutputService<TInput, TOutput> converter,
         ITypedMessagePublisher<TOutput> publisher)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _converter = converter ?? throw new ArgumentNullException(nameof(converter));
         _publisher = publisher ?? throw new ArgumentNullException(nameof(publisher));
-        _messageProcessing = metrics?.CreateSummary("message_processing", "Message processing duration in ms");
     }
 
     public async Task<ProcessedMessageStatus> HandleMessageAsync(MotorCloudEvent<TInput> dataCloudEvent,
@@ -35,16 +29,13 @@ public class MultiOutputServiceAdapter<TInput, TOutput> : INoOutputService<TInpu
     {
         try
         {
-            using (new AutoObserveStopwatch(() => _messageProcessing))
+            await foreach (var message in _converter.ConvertMessageAsync(dataCloudEvent, token)
+                               .ConfigureAwait(false).WithCancellation(token))
             {
-                await foreach (var message in _converter.ConvertMessageAsync(dataCloudEvent, token)
-                                   .ConfigureAwait(false).WithCancellation(token))
+                if (message?.Data is not null)
                 {
-                    if (message?.Data is not null)
-                    {
-                        await _publisher.PublishMessageAsync(message, token)
-                            .ConfigureAwait(false);
-                    }
+                    await _publisher.PublishMessageAsync(message, token)
+                        .ConfigureAwait(false);
                 }
             }
 

--- a/src/Motor.Extensions.Hosting/SingleOutputServiceAdapter.cs
+++ b/src/Motor.Extensions.Hosting/SingleOutputServiceAdapter.cs
@@ -9,9 +9,8 @@ public class SingleOutputServiceAdapter<TInput, TOutput> : MultiOutputServiceAda
     where TOutput : class
 {
     public SingleOutputServiceAdapter(ILogger<SingleOutputServiceAdapter<TInput, TOutput>> logger,
-        IMetricsFactory<SingleOutputServiceAdapter<TInput, TOutput>> metrics, ISingleOutputService<TInput, TOutput> service,
-        ITypedMessagePublisher<TOutput> publisher) :
-        base(logger, metrics, new SingleToMultiOutputAdapter<TInput, TOutput>(service), publisher)
+        ISingleOutputService<TInput, TOutput> service, ITypedMessagePublisher<TOutput> publisher) :
+        base(logger, new SingleToMultiOutputAdapter<TInput, TOutput>(service), publisher)
     {
     }
 }

--- a/test/Motor.Extensions.Diagnostics.Metrics_UnitTest/PrometheusDelegatingMessageHandlerTests.cs
+++ b/test/Motor.Extensions.Diagnostics.Metrics_UnitTest/PrometheusDelegatingMessageHandlerTests.cs
@@ -1,0 +1,22 @@
+using Moq;
+using Motor.Extensions.Diagnostics.Metrics;
+using Motor.Extensions.Diagnostics.Metrics.Abstractions;
+using Xunit;
+
+namespace Motor.Extensions.Diagnostics.Metrics_UnitTest;
+
+public class PrometheusDelegatingMessageHandlerTests
+{
+    [Fact]
+    public void Ctor_WithMetricsFactory_SummaryIsCreated()
+    {
+        var metricsFactoryMock = new Mock<IMetricsFactory<PrometheusDelegatingMessageHandler<string>>>();
+
+        var _ = new PrometheusDelegatingMessageHandler<string>(metricsFactoryMock.Object);
+
+        metricsFactoryMock.Verify(x =>
+            x.CreateSummary("message_processing", "Message processing duration in ms",
+                false, "status")
+    );
+    }
+}

--- a/test/Motor.Extensions.Hosting_UnitTest/MultiOutputServiceAdapterTests.cs
+++ b/test/Motor.Extensions.Hosting_UnitTest/MultiOutputServiceAdapterTests.cs
@@ -22,20 +22,6 @@ public class MultiOutputServiceAdapterTests
 
     private static Mock<ITypedMessagePublisher<string>> FakePublisher => new();
 
-
-    [Fact]
-    public void Ctor_WithMetricsFactory_SummaryIsCreated()
-    {
-        var metricsFactoryMock = new Mock<IMetricsFactory<SingleOutputServiceAdapter<string, string>>>();
-
-        GetMessageHandler(metrics: metricsFactoryMock.Object);
-
-        metricsFactoryMock.Verify(x =>
-            x.CreateSummary("message_processing", "Message processing duration in ms",
-                false, null as IReadOnlyList<QuantileEpsilonPair>, null, null, null)
-        );
-    }
-
     [Fact]
     public async Task HandleMessageAsync_WithContextAndInput_HasContext()
     {
@@ -180,7 +166,6 @@ public class MultiOutputServiceAdapterTests
 
     private MultiOutputServiceAdapter<string, string> GetMessageHandler(
         ILogger<SingleOutputServiceAdapter<string, string>>? logger = null,
-        IMetricsFactory<SingleOutputServiceAdapter<string, string>>? metrics = null,
         IMultiOutputService<string, string>? service = null,
         ITypedMessagePublisher<string>? publisher = null)
     {
@@ -188,7 +173,7 @@ public class MultiOutputServiceAdapterTests
         service ??= FakeService.Object;
         publisher ??= FakePublisher.Object;
 
-        return new MultiOutputServiceAdapter<string, string>(logger, metrics, service, publisher);
+        return new MultiOutputServiceAdapter<string, string>(logger, service, publisher);
     }
 
     private static MotorCloudEvent<string> CreateMotorEvent(string data = "")


### PR DESCRIPTION
This PR fixes #940 by moving the metric from `MultiOutputServiceAdapter` to `PrometheusDelegatingMessageHandler` and removes the now obsolete `message_processing_total` metric.