### PR TITLE
Fix broken OpenTelemetryProtocol exporter

### DIFF
--- a/Motor.NET.sln
+++ b/Motor.NET.sln
@@ -134,6 +134,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Motor.Extensions.Diagnostic
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsumeWithRabbitMQAndDeadLetterExchange", "examples\ConsumeWithRabbitMQAndDeadLetterExchange\ConsumeWithRabbitMQAndDeadLetterExchange.csproj", "{142BFD82-3C48-4E9A-9F9C-BF7401E057B4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Motor.Extensions.Diagnostics.Telemetry_IntegrationTest", "test\Motor.Extensions.Diagnostics.Telemetry_IntegrationTest\Motor.Extensions.Diagnostics.Telemetry_IntegrationTest.csproj", "{976B6FB8-CEB0-4544-A22F-3CF78348E43B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -840,6 +842,18 @@ Global
 		{142BFD82-3C48-4E9A-9F9C-BF7401E057B4}.Release|x64.Build.0 = Release|Any CPU
 		{142BFD82-3C48-4E9A-9F9C-BF7401E057B4}.Release|x86.ActiveCfg = Release|Any CPU
 		{142BFD82-3C48-4E9A-9F9C-BF7401E057B4}.Release|x86.Build.0 = Release|Any CPU
+		{976B6FB8-CEB0-4544-A22F-3CF78348E43B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{976B6FB8-CEB0-4544-A22F-3CF78348E43B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{976B6FB8-CEB0-4544-A22F-3CF78348E43B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{976B6FB8-CEB0-4544-A22F-3CF78348E43B}.Debug|x64.Build.0 = Debug|Any CPU
+		{976B6FB8-CEB0-4544-A22F-3CF78348E43B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{976B6FB8-CEB0-4544-A22F-3CF78348E43B}.Debug|x86.Build.0 = Debug|Any CPU
+		{976B6FB8-CEB0-4544-A22F-3CF78348E43B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{976B6FB8-CEB0-4544-A22F-3CF78348E43B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{976B6FB8-CEB0-4544-A22F-3CF78348E43B}.Release|x64.ActiveCfg = Release|Any CPU
+		{976B6FB8-CEB0-4544-A22F-3CF78348E43B}.Release|x64.Build.0 = Release|Any CPU
+		{976B6FB8-CEB0-4544-A22F-3CF78348E43B}.Release|x86.ActiveCfg = Release|Any CPU
+		{976B6FB8-CEB0-4544-A22F-3CF78348E43B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -903,6 +917,7 @@ Global
 		{DEDF2BF0-E680-4A8C-B828-F9075DF7369A} = {ADD2EBBA-A839-4E4A-9253-CDE29A372F07}
 		{0896B5BC-CA32-40E6-A7CF-E9EF288C0C81} = {749B1421-3177-4C7A-A66B-541BD4E925B0}
 		{142BFD82-3C48-4E9A-9F9C-BF7401E057B4} = {3DC7D216-6908-4759-B86F-759FDAE393D9}
+		{976B6FB8-CEB0-4544-A22F-3CF78348E43B} = {ADD2EBBA-A839-4E4A-9253-CDE29A372F07}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5E91C34C-3AEC-4084-BA02-753C9236AA34}

--- a/Motor.NET.sln.DotSettings
+++ b/Motor.NET.sln.DotSettings
@@ -3,4 +3,5 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=NATS/@EntryIndexedValue">NATS</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SQS/@EntryIndexedValue">SQS</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=nofile/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Otlp/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ulimit/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/examples/OpenTelemetryExample/appsettings.Development.json
+++ b/examples/OpenTelemetryExample/appsettings.Development.json
@@ -5,6 +5,6 @@
         }
     },
     "OtlpExporter": {
-        "AgentHost": "http://localhost:4317"
+        "Endpoint": "http://localhost:4317"
     }
 }

--- a/examples/OpenTelemetryExample/appsettings.json
+++ b/examples/OpenTelemetryExample/appsettings.json
@@ -10,7 +10,7 @@
         }
     },
     "OtlpExporter": {
-        "AgentHost": "http://agent-host.localhost:4317"
+        "Endpoint": "http://agent-host.localhost:4317"
     },
     "OpenTelemetry": {
         "SamplingProbability": 1,

--- a/src/Motor.Extensions.Conversion.JsonNet/Motor.Extensions.Conversion.JsonNet.csproj
+++ b/src/Motor.Extensions.Conversion.JsonNet/Motor.Extensions.Conversion.JsonNet.csproj
@@ -10,7 +10,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 

--- a/src/Motor.Extensions.Conversion.Protobuf/Motor.Extensions.Conversion.Protobuf.csproj
+++ b/src/Motor.Extensions.Conversion.Protobuf/Motor.Extensions.Conversion.Protobuf.csproj
@@ -11,7 +11,7 @@
 
     <ItemGroup>
         <PackageReference Include="Google.Protobuf" Version="3.24.3" />
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
     </ItemGroup>
 
     <Import Project="$(MSBuildThisFileDirectory)../../shared.csproj" />

--- a/src/Motor.Extensions.Conversion.SystemJson/Motor.Extensions.Conversion.SystemJson.csproj
+++ b/src/Motor.Extensions.Conversion.SystemJson/Motor.Extensions.Conversion.SystemJson.csproj
@@ -10,7 +10,7 @@
     </ItemGroup>
 
     <ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
 		<PackageReference Include="System.Text.Json" Version="7.0.3" />
     </ItemGroup>
 

--- a/src/Motor.Extensions.Diagnostics.Logging/Motor.Extensions.Diagnostics.Logging.csproj
+++ b/src/Motor.Extensions.Diagnostics.Logging/Motor.Extensions.Diagnostics.Logging.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="4.2.0" />
         <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />

--- a/src/Motor.Extensions.Diagnostics.Metrics/Motor.Extensions.Diagnostics.Metrics.csproj
+++ b/src/Motor.Extensions.Diagnostics.Metrics/Motor.Extensions.Diagnostics.Metrics.csproj
@@ -17,9 +17,9 @@
     <ItemGroup>
         <PackageReference Include="Prometheus.Client" Version="5.2.0" />
         <PackageReference Include="Prometheus.Client.AspNetCore" Version="5.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Motor.Extensions.Diagnostics.Queue.Metrics/Motor.Extensions.Diagnostics.Queue.Metrics.csproj
+++ b/src/Motor.Extensions.Diagnostics.Queue.Metrics/Motor.Extensions.Diagnostics.Queue.Metrics.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
       <PackageReference Include="Prometheus.Client" Version="5.2.0" />
     </ItemGroup>
 

--- a/src/Motor.Extensions.Diagnostics.Sentry/Motor.Extensions.Diagnostics.Sentry.csproj
+++ b/src/Motor.Extensions.Diagnostics.Sentry/Motor.Extensions.Diagnostics.Sentry.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
         <PackageReference Include="Sentry.Serilog" Version="3.39.1" />
     </ItemGroup>
 

--- a/src/Motor.Extensions.Diagnostics.Telemetry/Motor.Extensions.Diagnostics.Telemetry.csproj
+++ b/src/Motor.Extensions.Diagnostics.Telemetry/Motor.Extensions.Diagnostics.Telemetry.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
         <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.6.0" />
         <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.5.1" />
         <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.5.1" />

--- a/src/Motor.Extensions.Diagnostics.Telemetry/Motor.Extensions.Diagnostics.Telemetry.csproj
+++ b/src/Motor.Extensions.Diagnostics.Telemetry/Motor.Extensions.Diagnostics.Telemetry.csproj
@@ -6,12 +6,12 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-        <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.6.0" />
+        <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.7.0" />
         <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.5.1" />
-        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.5.1" />
-        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.4" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.14" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.4" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.1" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.7.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Motor.Extensions.Diagnostics.Telemetry/Motor.Extensions.Diagnostics.Telemetry.csproj
+++ b/src/Motor.Extensions.Diagnostics.Telemetry/Motor.Extensions.Diagnostics.Telemetry.csproj
@@ -12,6 +12,7 @@
         <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
         <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.1" />
         <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.7.1" />
+        
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Motor.Extensions.Hosting.Abstractions/Motor.Extensions.Hosting.Abstractions.csproj
+++ b/src/Motor.Extensions.Hosting.Abstractions/Motor.Extensions.Hosting.Abstractions.csproj
@@ -6,8 +6,8 @@
     
     <ItemGroup>
         <PackageReference Include="CloudNative.CloudEvents" Version="2.7.1" />
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/Motor.Extensions.Hosting.Kafka/Motor.Extensions.Hosting.Kafka.csproj
+++ b/src/Motor.Extensions.Hosting.Kafka/Motor.Extensions.Hosting.Kafka.csproj
@@ -8,8 +8,8 @@
         <PackageReference Include="Confluent.Kafka" Version="1.9.0" />
         <PackageReference Include="CloudNative.CloudEvents.Kafka" Version="2.7.0" />
         <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" Version="2.7.1" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
         <PackageReference Include="Polly" Version="8.2.0" />
         <PackageReference Include="System.Text.Json" Version="7.0.3" />
     </ItemGroup>

--- a/src/Motor.Extensions.Hosting.NATS/Motor.Extensions.Hosting.NATS.csproj
+++ b/src/Motor.Extensions.Hosting.NATS/Motor.Extensions.Hosting.NATS.csproj
@@ -6,8 +6,8 @@
 
     <ItemGroup>
         <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" Version="2.7.1" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
         <PackageReference Include="NATS.Client" Version="0.14.7" />
         <PackageReference Include="System.Text.Json" Version="7.0.3" />
     </ItemGroup>

--- a/src/Motor.Extensions.Hosting.RabbitMQ/Motor.Extensions.Hosting.RabbitMQ.csproj
+++ b/src/Motor.Extensions.Hosting.RabbitMQ/Motor.Extensions.Hosting.RabbitMQ.csproj
@@ -5,9 +5,9 @@
 	</PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
         <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" Version="2.7.1" />
         <PackageReference Include="RabbitMQ.Client" Version="6.5.0" />
     </ItemGroup>

--- a/src/Motor.Extensions.Hosting.SQS/Motor.Extensions.Hosting.SQS.csproj
+++ b/src/Motor.Extensions.Hosting.SQS/Motor.Extensions.Hosting.SQS.csproj
@@ -7,8 +7,8 @@
     <ItemGroup>
         <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.7" />
         <PackageReference Include="AWSSDK.SQS" Version="3.7.200.46" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     </ItemGroup>   
 
     <ItemGroup>

--- a/src/Motor.Extensions.Hosting.Timer/Motor.Extensions.Hosting.Timer.csproj
+++ b/src/Motor.Extensions.Hosting.Timer/Motor.Extensions.Hosting.Timer.csproj
@@ -5,8 +5,8 @@
 	</PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
         <PackageReference Include="Quartz" Version="3.7.0" />
     </ItemGroup>
 

--- a/src/Motor.Extensions.Hosting/Motor.Extensions.Hosting.csproj
+++ b/src/Motor.Extensions.Hosting/Motor.Extensions.Hosting.csproj
@@ -12,8 +12,8 @@
     </ItemGroup>
     
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
-      <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="7.0.11" />
+      <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+      <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.01" />
     </ItemGroup>
 
     <Import Project="$(MSBuildThisFileDirectory)../../shared.csproj" />

--- a/src/Motor.Extensions.Http/Motor.Extensions.Http.csproj
+++ b/src/Motor.Extensions.Http/Motor.Extensions.Http.csproj
@@ -5,10 +5,10 @@
 	</PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.11" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.01" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/Motor.Extensions.Conversion.JsonNet_UnitTest/Motor.Extensions.Conversion.JsonNet_UnitTest.csproj
+++ b/test/Motor.Extensions.Conversion.JsonNet_UnitTest/Motor.Extensions.Conversion.JsonNet_UnitTest.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
         <PackageReference Include="xunit" Version="2.5.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">

--- a/test/Motor.Extensions.Conversion.Protobuf_UnitTest/Motor.Extensions.Conversion.Protobuf_UnitTest.csproj
+++ b/test/Motor.Extensions.Conversion.Protobuf_UnitTest/Motor.Extensions.Conversion.Protobuf_UnitTest.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
         <PackageReference Include="xunit" Version="2.5.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">

--- a/test/Motor.Extensions.Conversion.SystemJson_UnitTest/Motor.Extensions.Conversion.SystemJson_UnitTest.csproj
+++ b/test/Motor.Extensions.Conversion.SystemJson_UnitTest/Motor.Extensions.Conversion.SystemJson_UnitTest.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
         <PackageReference Include="xunit" Version="2.5.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">

--- a/test/Motor.Extensions.Diagnostics.Telemetry_IntegrationTest/Motor.Extensions.Diagnostics.Telemetry_IntegrationTest.csproj
+++ b/test/Motor.Extensions.Diagnostics.Telemetry_IntegrationTest/Motor.Extensions.Diagnostics.Telemetry_IntegrationTest.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="xunit" Version="2.5.1"/>
+        <PackageReference Include="Moq" Version="4.20.69"/>
+        <PackageReference Include="TestContainers" Version="3.5.0"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Motor.Extensions.TestUtilities\Motor.Extensions.TestUtilities.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Update="appsettings-otlp.json">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+        <None Update="OpenTelemetryCollector.Dockerfile">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
+
+</Project>

--- a/test/Motor.Extensions.Diagnostics.Telemetry_IntegrationTest/OpenTelemetryCollector.Dockerfile
+++ b/test/Motor.Extensions.Diagnostics.Telemetry_IntegrationTest/OpenTelemetryCollector.Dockerfile
@@ -1,0 +1,1 @@
+FROM otel/opentelemetry-collector:0.96.0

--- a/test/Motor.Extensions.Diagnostics.Telemetry_IntegrationTest/OpenTelemetryCollectorFixture.cs
+++ b/test/Motor.Extensions.Diagnostics.Telemetry_IntegrationTest/OpenTelemetryCollectorFixture.cs
@@ -1,0 +1,44 @@
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using Polly;
+using Xunit;
+
+namespace Motor.Extensions.Diagnostics.Telemetry_IntegrationTest;
+
+public class OpenTelemetryCollectorFixture : IAsyncLifetime
+{
+    private const int OtlpPort = 4317;
+
+    private IContainer? Container { get; set; }
+
+    public Uri Endpoint => new($"http://{Container!.Hostname}:{Container!.GetMappedPublicPort(OtlpPort)}");
+
+    public async Task<bool> ReceivedSpanAsync(string spanId) =>
+        await Policy.HandleResult(false)
+            .WaitAndRetryAsync(10, _ => TimeSpan.FromSeconds(1))
+            .ExecuteAsync(async () =>
+            {
+                var (_, stderr) = await Container!.GetLogsAsync(timestampsEnabled: false).ConfigureAwait(false);
+                return stderr.Contains(spanId);
+            });
+
+    public async Task InitializeAsync()
+    {
+        var dockerImage = new ImageFromDockerfileBuilder()
+            .WithDockerfile("OpenTelemetryCollector.Dockerfile")
+            .Build();
+        await dockerImage.CreateAsync();
+        Container = new ContainerBuilder()
+            .WithImage(dockerImage)
+            .WithPortBinding(OtlpPort, true)
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged(
+                @"Everything is ready\. Begin running and processing data\."))
+            .Build();
+        await Container.StartAsync();
+    }
+
+    public Task DisposeAsync()
+    {
+        return Container!.StopAsync();
+    }
+}

--- a/test/Motor.Extensions.Diagnostics.Telemetry_IntegrationTest/OpenTelemetryTests.cs
+++ b/test/Motor.Extensions.Diagnostics.Telemetry_IntegrationTest/OpenTelemetryTests.cs
@@ -1,0 +1,126 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Moq;
+using Motor.Extensions.Conversion.Abstractions;
+using Motor.Extensions.Diagnostics.Logging;
+using Motor.Extensions.Diagnostics.Metrics;
+using Motor.Extensions.Diagnostics.Telemetry;
+using Motor.Extensions.Hosting;
+using Motor.Extensions.Hosting.Abstractions;
+using Motor.Extensions.Hosting.CloudEvents;
+using Motor.Extensions.Hosting.Consumer;
+using Motor.Extensions.Hosting.Publisher;
+using Motor.Extensions.TestUtilities;
+using Motor.Extensions.Utilities;
+using Motor.Extensions.Utilities.Abstractions;
+using OpenTelemetry.Exporter;
+using Serilog;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Motor.Extensions.Diagnostics.Telemetry_IntegrationTest;
+
+public class OpenTelemetryTests : IDisposable, IClassFixture<OpenTelemetryCollectorFixture>
+{
+    private readonly ActivityListener _listener;
+    private readonly OpenTelemetryCollectorFixture _otlpFixture;
+
+    public OpenTelemetryTests(ITestOutputHelper outputHelper, OpenTelemetryCollectorFixture otlpFixture)
+    {
+        _listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == OpenTelemetryOptions.DefaultActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) =>
+                ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStarted = _ => { outputHelper.WriteLine("test"); }
+        };
+        ActivitySource.AddActivityListener(_listener);
+        _otlpFixture = otlpFixture;
+    }
+
+    [Fact]
+    public async Task StartAsync_ConfiguredOtlp_TracePublishedWithOtlp()
+    {
+        var consumer = new InMemoryConsumer<string>();
+        var publisher = new InMemoryPublisher<string>();
+        using var host = GetReverseStringService(consumer, publisher, "appsettings-otlp.json", builder =>
+            builder.ConfigureServices((_, services) =>
+            {
+                services.Configure<OtlpExporterOptions>(options => options.Endpoint = _otlpFixture.Endpoint);
+            }));
+        await host.StartAsync();
+        var randomActivity = CreateRandomActivity();
+        var motorCloudEvent = MotorCloudEvent.CreateTestCloudEvent(Array.Empty<byte>());
+        motorCloudEvent.SetActivity(randomActivity);
+
+        await consumer.AddMessage(motorCloudEvent);
+
+        var ctx = publisher.Events.First().GetActivityContext();
+        Assert.True(await _otlpFixture.ReceivedSpanAsync(ctx.SpanId.ToString()));
+        await host.StopAsync();
+    }
+
+    private static Activity CreateRandomActivity()
+    {
+        var activity = new Activity(nameof(CreateRandomActivity));
+        activity.SetIdFormat(ActivityIdFormat.W3C);
+        activity.Start();
+        return activity;
+    }
+
+    private static IHost GetReverseStringService(InMemoryConsumer<string> consumer, InMemoryPublisher<string> publisher,
+        string? appSettings, params Func<IMotorHostBuilder, IMotorHostBuilder>[] extraConfigurations)
+    {
+        var motorHostBuilder = new MotorHostBuilder(new HostBuilder(), false)
+            .UseSetting(MotorHostDefaults.EnablePrometheusEndpointKey, false.ToString())
+            .ConfigureSerilog()
+            .ConfigurePrometheus()
+            .ConfigureOpenTelemetry()
+            .ConfigureServices((_, services) =>
+            {
+                services.AddTransient(_ =>
+                {
+                    var mock = new Mock<IApplicationNameService>();
+                    mock.Setup(t => t.GetFullName()).Returns("test");
+                    mock.Setup(t => t.GetVersion()).Returns("test");
+                    mock.Setup(t => t.GetLibVersion()).Returns("test");
+                    mock.Setup(t => t.GetSource()).Returns(new Uri("motor://test"));
+                    return mock.Object;
+                });
+                services.AddTransient<ISingleOutputService<string, string>, ReverseStringConverter>();
+                services.AddTransient<IMessageSerializer<string>, StringSerializer>();
+                services.AddTransient<IMessageDeserializer<string>, StringDeserializer>();
+                services.AddTransient<INoOutputService<string>, SingleOutputServiceAdapter<string, string>>();
+                services.AddTransient<DelegatingMessageHandler<string>, TelemetryDelegatingMessageHandler<string>>();
+                services.AddQueuedGenericService<string>();
+                services.AddLogging(loggingBuilder => loggingBuilder.AddSerilog(dispose: true));
+            })
+            .ConfigureConsumer<string>((_, builder) =>
+            {
+                builder.AddInMemory(consumer);
+                builder.AddDeserializer<StringDeserializer>();
+            })
+            .ConfigurePublisher<string>((_, builder) =>
+            {
+                builder.AddInMemory(publisher);
+                builder.AddSerializer<StringSerializer>();
+            });
+        motorHostBuilder = extraConfigurations.Aggregate(motorHostBuilder, (builder, func) => func.Invoke(builder));
+        if (appSettings is not null)
+        {
+            motorHostBuilder.ConfigureAppConfiguration((_, config) =>
+            {
+                config.AddJsonFile(appSettings, false, false);
+            });
+        }
+        return motorHostBuilder.Build();
+    }
+
+
+    public void Dispose()
+    {
+        _listener.Dispose();
+    }
+}

--- a/test/Motor.Extensions.Diagnostics.Telemetry_IntegrationTest/ReverseStringConverter.cs
+++ b/test/Motor.Extensions.Diagnostics.Telemetry_IntegrationTest/ReverseStringConverter.cs
@@ -1,0 +1,56 @@
+using System.Diagnostics;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Motor.Extensions.Conversion.Abstractions;
+using Motor.Extensions.Diagnostics.Metrics.Abstractions;
+using Motor.Extensions.Diagnostics.Telemetry;
+using Motor.Extensions.Hosting.Abstractions;
+using Motor.Extensions.Hosting.CloudEvents;
+using Prometheus.Client;
+
+namespace Motor.Extensions.Diagnostics.Telemetry_IntegrationTest;
+
+public class ReverseStringConverter : ISingleOutputService<string, string>
+{
+    private readonly ILogger<ReverseStringConverter> _logger;
+    private readonly IMetricFamily<ISummary> _summary;
+    private static readonly ActivitySource ActivitySource = new(OpenTelemetryOptions.DefaultActivitySourceName);
+
+    public ReverseStringConverter(ILogger<ReverseStringConverter> logger,
+        IMetricsFactory<ReverseStringConverter> metricsFactory)
+    {
+        _logger = logger;
+        _summary = metricsFactory.CreateSummary("summaryName", "summaryHelpString", new[] { "someLabel" });
+    }
+
+    public Task<MotorCloudEvent<string>?> ConvertMessageAsync(MotorCloudEvent<string> dataCloudEvent,
+        CancellationToken token = default)
+    {
+        _logger.LogInformation("log your request");
+        var tmpChar = dataCloudEvent.TypedData.ToCharArray();
+        if (!ActivitySource.HasListeners())
+        {
+            throw new ArgumentException();
+        }
+
+        var reversed = tmpChar.Reverse().ToArray();
+        _summary.WithLabels("collect_your_metrics").Observe(1.0);
+        return Task.FromResult<MotorCloudEvent<string>?>(dataCloudEvent.CreateNew(new string(reversed)));
+    }
+}
+
+public class StringSerializer : IMessageSerializer<string>
+{
+    public byte[] Serialize(string message)
+    {
+        return Encoding.UTF8.GetBytes(message);
+    }
+}
+
+public class StringDeserializer : IMessageDeserializer<string>
+{
+    public string Deserialize(byte[] message)
+    {
+        return Encoding.UTF8.GetString(message);
+    }
+}

--- a/test/Motor.Extensions.Diagnostics.Telemetry_IntegrationTest/appsettings-otlp.json
+++ b/test/Motor.Extensions.Diagnostics.Telemetry_IntegrationTest/appsettings-otlp.json
@@ -1,0 +1,9 @@
+{
+  "OtlpExporter": {
+    "Endpoint": "http://placeholder:1337"
+  },
+  "OpenTelemetry": {
+    "SamplingProbability": 1,
+    "Sources": ["OpenTelemetryExample"]
+  }
+}

--- a/test/Motor.Extensions.Hosting.RabbitMQ_IntegrationTest/Motor.Extensions.Hosting.RabbitMQ_IntegrationTest.csproj
+++ b/test/Motor.Extensions.Hosting.RabbitMQ_IntegrationTest/Motor.Extensions.Hosting.RabbitMQ_IntegrationTest.csproj
@@ -15,10 +15,10 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
         <PackageReference Include="Polly" Version="8.2.0" />
     </ItemGroup>
 

--- a/test/Motor.Extensions.Hosting.Timer_IntegrationTest/Motor.Extensions.Hosting.Timer_IntegrationTest.csproj
+++ b/test/Motor.Extensions.Hosting.Timer_IntegrationTest/Motor.Extensions.Hosting.Timer_IntegrationTest.csproj
@@ -12,7 +12,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/Motor.Extensions.Hosting_IntegrationTest/Motor.Extensions.Hosting_IntegrationTest.csproj
+++ b/test/Motor.Extensions.Hosting_IntegrationTest/Motor.Extensions.Hosting_IntegrationTest.csproj
@@ -14,9 +14,9 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/Motor.Extensions.Http_UnitTest/Motor.Extensions.Http_UnitTest.csproj
+++ b/test/Motor.Extensions.Http_UnitTest/Motor.Extensions.Http_UnitTest.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
         <PackageReference Include="Moq" Version="4.20.69" />
         <PackageReference Include="xunit" Version="2.5.1" />


### PR DESCRIPTION
Fixes #987 

The API for OpenTelemetry has somewhat changed, so I needed to refactor some of the code in [`TelemetryHostBuilderExtensions`](https://github.com/GDATASoftwareAG/motornet/compare/fix-otlp?expand=1#diff-ab96e507f98b03c63ac7900ca9e440811ea69d002f410b98a331f6650d03249b). The changes even reduce the complexity a bit.

As always, the separated commits are meant to make reviews easier and will be squashed before merging.