### PR TITLE
Safely close Kafka consumer

### DIFF
--- a/src/Motor.Extensions.Hosting.Kafka/KafkaMessageConsumer.cs
+++ b/src/Motor.Extensions.Hosting.Kafka/KafkaMessageConsumer.cs
@@ -123,7 +123,7 @@ public sealed class KafkaMessageConsumer<TData> : IMessageConsumer<TData>, IDisp
 
     public Task StopAsync(CancellationToken token = default)
     {
-        _consumer?.Close();
+        CloseOrDispose();
         return Task.CompletedTask;
     }
 
@@ -359,6 +359,22 @@ public sealed class KafkaMessageConsumer<TData> : IMessageConsumer<TData>, IDisp
         if (disposing)
         {
             _timer.Dispose();
+            CloseOrDispose();
+        }
+    }
+
+    private void CloseOrDispose()
+    {
+        try
+        {
+            _consumer?.Close();
+        }
+        catch (ObjectDisposedException)
+        {
+            // thrown if the consumer is already closed
+        }
+        finally
+        {
             _consumer?.Dispose();
         }
     }

--- a/test/Motor.Extensions.Hosting.Kafka_IntegrationTest/KafkaExtensionTests.cs
+++ b/test/Motor.Extensions.Hosting.Kafka_IntegrationTest/KafkaExtensionTests.cs
@@ -42,6 +42,18 @@ public class KafkaExtensionTests : IClassFixture<KafkaFixture>
     }
 
     [Fact(Timeout = 50000)]
+    public async Task StopAsync_AlreadyDisposed_NoException()
+    {
+        var consumer = GetConsumer<string>(_topic);
+        consumer.ConsumeCallbackAsync = async (_, _) => await Task.FromResult(ProcessedMessageStatus.Success);
+        await consumer.StartAsync();
+        _ = consumer.ExecuteAsync();
+        consumer.Dispose();
+
+        await consumer.StopAsync();
+    }
+
+    [Fact(Timeout = 50000)]
     public async Task Consume_RawPublishIntoKafkaAndConsumeCreateCloudEvent_ConsumedEqualsPublished()
     {
         const string message = "testMessage";


### PR DESCRIPTION
Fixes #1283

Calling both `Dispose()` and `Close()` on a consumer will yield an exception that the inner handler has already been disposed. Since there are two possible ways a KafkaMessageConsumer can be stopped, I migrated both of them to call a safe `CloseOrDispose()` method.