### PR TITLE
Update prometheus client to version 6.1.0

### DIFF
--- a/src/Motor.Extensions.Diagnostics.Metrics.Abstractions/Motor.Extensions.Diagnostics.Metrics.Abstractions.csproj
+++ b/src/Motor.Extensions.Diagnostics.Metrics.Abstractions/Motor.Extensions.Diagnostics.Metrics.Abstractions.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Prometheus.Client" Version="5.2.0" />
+        <PackageReference Include="Prometheus.Client" Version="6.1.0" />
     </ItemGroup>
 
     <Import Project="$(MSBuildThisFileDirectory)../../shared.csproj" />

--- a/src/Motor.Extensions.Diagnostics.Metrics/Motor.Extensions.Diagnostics.Metrics.csproj
+++ b/src/Motor.Extensions.Diagnostics.Metrics/Motor.Extensions.Diagnostics.Metrics.csproj
@@ -16,8 +16,8 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.6" />
-        <PackageReference Include="Prometheus.Client" Version="5.2.0" />
-        <PackageReference Include="Prometheus.Client.AspNetCore" Version="5.0.0" />
+        <PackageReference Include="Prometheus.Client" Version="6.1.0" />
+        <PackageReference Include="Prometheus.Client.AspNetCore" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.1" />
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.1" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.1" />

--- a/src/Motor.Extensions.Diagnostics.Metrics/MotorMetricsFactory.cs
+++ b/src/Motor.Extensions.Diagnostics.Metrics/MotorMetricsFactory.cs
@@ -25,7 +25,7 @@ public class MotorMetricsFactory : IMotorMetricsFactory
     )
     {
         var prometheusConfig = options.Value ?? throw new ArgumentNullException(nameof(options), "Prometheus config doesn't exist.");
-        _collectorRegistry = prometheusConfig.CollectorRegistryInstance ?? Prometheus.Client.Metrics.DefaultCollectorRegistry;
+        _collectorRegistry = prometheusConfig.CollectorRegistry ?? Prometheus.Client.Metrics.DefaultCollectorRegistry;
 
         _collectorRegistry.GetOrAdd(
             ThreadPoolGauge.ThreadPoolGaugeConfig,

--- a/src/Motor.Extensions.Diagnostics.Metrics/ThreadPoolGauge.cs
+++ b/src/Motor.Extensions.Diagnostics.Metrics/ThreadPoolGauge.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using Prometheus.Client;
@@ -17,7 +18,8 @@ internal class ThreadPoolGauge : ICollector
         "motor_extensions_diagnostics_metrics_threadpoolstate",
         "Expose information about the internal .NET global ThreadPool",
         Labels,
-        false
+        false,
+        TimeSpan.Zero
     );
 
     public void Collect(IMetricsWriter writer)

--- a/src/Motor.Extensions.Diagnostics.Queue.Metrics/Motor.Extensions.Diagnostics.Queue.Metrics.csproj
+++ b/src/Motor.Extensions.Diagnostics.Queue.Metrics/Motor.Extensions.Diagnostics.Queue.Metrics.csproj
@@ -6,7 +6,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.6" />
-      <PackageReference Include="Prometheus.Client" Version="5.2.0" />
+      <PackageReference Include="Prometheus.Client" Version="6.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Motor.Extensions.Diagnostics.Queue.Metrics/QueueMonitorMetricsCollector.cs
+++ b/src/Motor.Extensions.Diagnostics.Queue.Metrics/QueueMonitorMetricsCollector.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -19,14 +20,16 @@ internal class QueueMonitorMetricsCollector : ICollector
         "motor_extensions_diagnostics_queue_metrics_messages_ready",
         "Expose information about how many messages are ready to be processed",
         Labels,
-        false
+        false,
+        TimeSpan.Zero
     );
 
     private static readonly MetricConfiguration ActiveConsumersGaugeConfig = new(
         "motor_extensions_diagnostics_queue_metrics_active_consumers",
         "Expose information about how many active consumers are listening on the queue",
         Labels,
-        false
+        false,
+        TimeSpan.Zero
     );
 
     private readonly IEnumerable<IQueueMonitor> _queueMonitors;


### PR DESCRIPTION
* One name changed
* some constructors now have a timespan parameter to tell how long the collected series should live for
  * Timespan.Zero is the default which disables the new feature
  * Author says that he tried to keep backwards compatibility for most methods, but some need to be adjusted
  * See https://github.com/prom-client-net/prom-client/pull/343