### PR TITLE
Allow 20 parallel PRs for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,4 @@ updates:
   schedule:
     interval: daily
     time: "04:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 20


### PR DESCRIPTION
Dependabot has been disabled for a while now. There are many updates waiting and I would like to reduce the number of times I have to restart dependabot.