### PR TITLE
Enable merge groups

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,5 +1,7 @@
 name: Dependabot auto-merge
-on: pull_request
+on:
+  pull_request:
+  merge_group:
 
 permissions:
   contents: write

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -5,6 +5,8 @@ on:
     branches: ["master"]
   pull_request:
     branches: ["master"]
+  merge_group:
+    types: [checks_requested]
   release:
     types:
       - published


### PR DESCRIPTION
With so many open dependabot PRs, managing the PRs is easier if using merge groups instead of rebasing them one by one.