### PR TITLE
Add StartedBackgroundService

### DIFF
--- a/Motor.NET.sln
+++ b/Motor.NET.sln
@@ -144,6 +144,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspNetExample_IntegrationTe
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Motor.Extensions.Hosting.AspNet_IntegrationTest", "test\Motor.Extensions.Hosting.AspNet_IntegrationTest\Motor.Extensions.Hosting.AspNet_IntegrationTest.csproj", "{10B162DC-0237-487E-8F0A-FC6AA0CF6C9D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Motor.Extensions.Hosting.BackgroundService", "src\Motor.Extensions.Hosting.BackgroundService\Motor.Extensions.Hosting.BackgroundService.csproj", "{97CE5FF3-5346-48B1-93F7-E4580A6749CB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Motor.Extensions.Hosting.BackgroundService_IntegrationTest", "test\Motor.Extensions.Hosting.BackgroundService_IntegrationTest\Motor.Extensions.Hosting.BackgroundService_IntegrationTest.csproj", "{B64C7A3C-1D67-4C08-86D3-857E406E4F51}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -910,6 +914,30 @@ Global
 		{10B162DC-0237-487E-8F0A-FC6AA0CF6C9D}.Release|x64.Build.0 = Release|Any CPU
 		{10B162DC-0237-487E-8F0A-FC6AA0CF6C9D}.Release|x86.ActiveCfg = Release|Any CPU
 		{10B162DC-0237-487E-8F0A-FC6AA0CF6C9D}.Release|x86.Build.0 = Release|Any CPU
+		{97CE5FF3-5346-48B1-93F7-E4580A6749CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{97CE5FF3-5346-48B1-93F7-E4580A6749CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{97CE5FF3-5346-48B1-93F7-E4580A6749CB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{97CE5FF3-5346-48B1-93F7-E4580A6749CB}.Debug|x64.Build.0 = Debug|Any CPU
+		{97CE5FF3-5346-48B1-93F7-E4580A6749CB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{97CE5FF3-5346-48B1-93F7-E4580A6749CB}.Debug|x86.Build.0 = Debug|Any CPU
+		{97CE5FF3-5346-48B1-93F7-E4580A6749CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{97CE5FF3-5346-48B1-93F7-E4580A6749CB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{97CE5FF3-5346-48B1-93F7-E4580A6749CB}.Release|x64.ActiveCfg = Release|Any CPU
+		{97CE5FF3-5346-48B1-93F7-E4580A6749CB}.Release|x64.Build.0 = Release|Any CPU
+		{97CE5FF3-5346-48B1-93F7-E4580A6749CB}.Release|x86.ActiveCfg = Release|Any CPU
+		{97CE5FF3-5346-48B1-93F7-E4580A6749CB}.Release|x86.Build.0 = Release|Any CPU
+		{B64C7A3C-1D67-4C08-86D3-857E406E4F51}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B64C7A3C-1D67-4C08-86D3-857E406E4F51}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B64C7A3C-1D67-4C08-86D3-857E406E4F51}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B64C7A3C-1D67-4C08-86D3-857E406E4F51}.Debug|x64.Build.0 = Debug|Any CPU
+		{B64C7A3C-1D67-4C08-86D3-857E406E4F51}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B64C7A3C-1D67-4C08-86D3-857E406E4F51}.Debug|x86.Build.0 = Debug|Any CPU
+		{B64C7A3C-1D67-4C08-86D3-857E406E4F51}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B64C7A3C-1D67-4C08-86D3-857E406E4F51}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B64C7A3C-1D67-4C08-86D3-857E406E4F51}.Release|x64.ActiveCfg = Release|Any CPU
+		{B64C7A3C-1D67-4C08-86D3-857E406E4F51}.Release|x64.Build.0 = Release|Any CPU
+		{B64C7A3C-1D67-4C08-86D3-857E406E4F51}.Release|x86.ActiveCfg = Release|Any CPU
+		{B64C7A3C-1D67-4C08-86D3-857E406E4F51}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -978,6 +1006,8 @@ Global
 		{AEE71C6A-D2A2-46D3-B26F-990757DA4725} = {3DC7D216-6908-4759-B86F-759FDAE393D9}
 		{2475AEA4-1F5D-45CC-92A3-74269E488C70} = {3DC7D216-6908-4759-B86F-759FDAE393D9}
 		{10B162DC-0237-487E-8F0A-FC6AA0CF6C9D} = {ADD2EBBA-A839-4E4A-9253-CDE29A372F07}
+		{97CE5FF3-5346-48B1-93F7-E4580A6749CB} = {749B1421-3177-4C7A-A66B-541BD4E925B0}
+		{B64C7A3C-1D67-4C08-86D3-857E406E4F51} = {ADD2EBBA-A839-4E4A-9253-CDE29A372F07}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5E91C34C-3AEC-4084-BA02-753C9236AA34}

--- a/src/Motor.Extensions.Hosting.BackgroundService/LogEvents.cs
+++ b/src/Motor.Extensions.Hosting.BackgroundService/LogEvents.cs
@@ -1,0 +1,10 @@
+using Microsoft.Extensions.Logging;
+
+namespace Motor.Extensions.Hosting.BackgroundService;
+
+public static class LogEvents
+{
+    public static readonly EventId FailedToStart = new(0, nameof(FailedToStart));
+    public static readonly EventId Failure = new(1, nameof(Failure));
+    public static readonly EventId FinishedSuccessfully = new(2, nameof(FinishedSuccessfully));
+}

--- a/src/Motor.Extensions.Hosting.BackgroundService/Motor.Extensions.Hosting.BackgroundService.csproj
+++ b/src/Motor.Extensions.Hosting.BackgroundService/Motor.Extensions.Hosting.BackgroundService.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
+    </ItemGroup>
+
+    <Import Project="$(MSBuildThisFileDirectory)../../shared.csproj" />
+
+</Project>

--- a/src/Motor.Extensions.Hosting.BackgroundService/StartedBackgroundService.cs
+++ b/src/Motor.Extensions.Hosting.BackgroundService/StartedBackgroundService.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Motor.Extensions.Hosting.BackgroundService;
+
+public abstract class StartedBackgroundService : Microsoft.Extensions.Hosting.BackgroundService
+{
+    protected StartedBackgroundService(IHostApplicationLifetime appLifetime, ILogger<StartedBackgroundService> logger)
+    {
+        _appLifetime = appLifetime;
+        _logger = logger;
+    }
+
+    private readonly IHostApplicationLifetime _appLifetime;
+    private readonly ILogger<StartedBackgroundService> _logger;
+    protected abstract Task ExecuteWhenStartedAsync(CancellationToken stoppingToken);
+
+    protected override async Task ExecuteAsync(CancellationToken ct)
+    {
+        try
+        {
+            if (!await AppStartedSuccessfullyAsync(ct))
+            {
+                _logger.LogError(LogEvents.FailedToStart, "Failed to start successfully");
+                return;
+            }
+            await ExecuteWhenStartedAsync(ct);
+            _logger.LogInformation(LogEvents.FinishedSuccessfully, "Finished Successfully");
+        }
+        catch (Exception e)
+        {
+            _logger.LogCritical(LogEvents.Failure, e, "Something went wrong: {Error}", e.Message);
+            Environment.ExitCode = 1;
+        }
+        finally
+        {
+            _appLifetime.StopApplication();
+        }
+    }
+
+    /// <summary>
+    /// Waits until the app is fully started and returns the success.
+    /// This is important because <tt>StopApplication()</tt> should never be called before an app is started completely.
+    /// </summary>
+    /// <returns><tt>true</tt> if started successfully, <tt>false</tt> otherwise</returns>
+    private async Task<bool> AppStartedSuccessfullyAsync(CancellationToken stoppingToken)
+    {
+        // Taken from https://andrewlock.net/finding-the-urls-of-an-aspnetcore-app-from-a-hosted-service-in-dotnet-6/
+        var startedSource = new TaskCompletionSource();
+        var cancelledSource = new TaskCompletionSource();
+
+        await using (_appLifetime.ApplicationStarted.Register(() => startedSource.SetResult()))
+        await using (stoppingToken.Register(() => cancelledSource.SetResult()))
+        {
+            var completedTask = await Task.WhenAny(startedSource.Task, cancelledSource.Task).ConfigureAwait(false);
+
+            // If the completed task was the "app started" task, return true, otherwise false
+            return completedTask == startedSource.Task;
+        }
+    }
+}

--- a/test/Motor.Extensions.Hosting.BackgroundService_IntegrationTest/BackgroundServiceTests.cs
+++ b/test/Motor.Extensions.Hosting.BackgroundService_IntegrationTest/BackgroundServiceTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Motor.Extensions.Hosting.BackgroundService_IntegrationTest.TestExample;
+using Motor.Extensions.Hosting.BackgroundService;
+using Motor.Extensions.TestUtilities;
+using Xunit;
+
+namespace Motor.Extensions.Hosting.BackgroundService_IntegrationTest;
+
+public class BackgroundServiceTests
+{
+    [Fact]
+    public async Task WaitUntilHealthy_UnsafeHostedService_ThrowsException()
+    {
+        await using var host = MotorTestHost
+            .BasedOn<ExampleProgram>()
+            .ConfigureServices(services =>
+            {
+                services.AddHostedService<UnsafeHostedService>();
+                services.AddHostedService<BackgroundStartupTask>();
+            })
+            .Build();
+
+        Assert.Throws<Exception>(() => host.Services.GetRequiredService<ISharedService>());
+    }
+
+    private class UnsafeHostedService(ISharedService service) : Microsoft.Extensions.Hosting.BackgroundService
+    {
+        protected override Task ExecuteAsync(CancellationToken ct)
+        {
+            if (!service.IsStarted())
+            {
+                throw new Exception("Service not started");
+            }
+
+            service.Finish();
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task WaitUntilHealthy_SafeHostedService_StartsSuccessfully()
+    {
+        await using var host = MotorTestHost.BasedOn<ExampleProgram>()
+            .ConfigureServices(services =>
+            {
+                services.AddHostedService<BackgroundStartupTask>();
+                services.AddHostedService<SafeHostedService>();
+            })
+            .Build();
+        var sharedService = host.Services.GetRequiredService<ISharedService>();
+
+        Assert.True(sharedService.IsFinished());
+    }
+
+    public class SafeHostedService(ISharedService service,
+        IHostApplicationLifetime appLifetime,
+        ILogger<StartedBackgroundService> logger)
+        : StartedBackgroundService(appLifetime, logger)
+    {
+        protected override Task ExecuteWhenStartedAsync(CancellationToken ct)
+        {
+            if (!service.IsStarted())
+            {
+                throw new Exception("Service not started");
+            }
+
+            service.Finish();
+            return Task.CompletedTask;
+        }
+    }
+
+    public class BackgroundStartupTask(ISharedService sharedService) : IHostedService
+    {
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            sharedService.Start();
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+}

--- a/test/Motor.Extensions.Hosting.BackgroundService_IntegrationTest/Motor.Extensions.Hosting.BackgroundService_IntegrationTest.csproj
+++ b/test/Motor.Extensions.Hosting.BackgroundService_IntegrationTest/Motor.Extensions.Hosting.BackgroundService_IntegrationTest.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <IsPackable>false</IsPackable>
+        <Nullable>enable</Nullable>
+        <Product>Motor.NET Integration Test</Product>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0"/>
+        <PackageReference Include="xunit" Version="2.9.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Motor.Extensions.Hosting.BackgroundService\Motor.Extensions.Hosting.BackgroundService.csproj" />
+        <ProjectReference Include="..\..\src\Motor.Extensions.TestUtilities\Motor.Extensions.TestUtilities.csproj" />
+        <ProjectReference Include="..\..\src\Motor.Extensions.Utilities\Motor.Extensions.Utilities.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/test/Motor.Extensions.Hosting.BackgroundService_IntegrationTest/TestExample/ExampleProgram.cs
+++ b/test/Motor.Extensions.Hosting.BackgroundService_IntegrationTest/TestExample/ExampleProgram.cs
@@ -1,0 +1,19 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Motor.Extensions.Hosting.BackgroundService_IntegrationTest.TestExample;
+using Motor.Extensions.Utilities;
+
+await MotorHost
+    .CreateDefaultBuilder()
+    .ConfigureServices((_, services) =>
+    {
+        services.AddSingleton<ISharedService, SharedService>();
+    })
+    .RunConsoleAsync();
+
+public class ExampleProgram
+{
+    protected ExampleProgram()
+    {
+    }
+}

--- a/test/Motor.Extensions.Hosting.BackgroundService_IntegrationTest/TestExample/SharedService.cs
+++ b/test/Motor.Extensions.Hosting.BackgroundService_IntegrationTest/TestExample/SharedService.cs
@@ -1,0 +1,35 @@
+namespace Motor.Extensions.Hosting.BackgroundService_IntegrationTest.TestExample;
+
+public interface ISharedService
+{
+    public void Start();
+    public bool IsStarted();
+    public void Finish();
+    public bool IsFinished();
+}
+
+public class SharedService : ISharedService
+{
+    private bool _started;
+    private bool _finished;
+
+    public void Start()
+    {
+        _started = true;
+    }
+
+    public bool IsStarted()
+    {
+        return _started;
+    }
+
+    public void Finish()
+    {
+        _finished = true;
+    }
+
+    public bool IsFinished()
+    {
+        return _finished;
+    }
+}


### PR DESCRIPTION
When multiple `IHostedService`s are used within a program, which is often the case with Kestrel, there is no guarantee the intended main service is started after the other background services.

Using `StartedBackgroundService`, this behavior is ensured.