### PR TITLE
Disable Testcontainers.Kafka Upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,5 @@ updates:
     interval: daily
     time: "04:00"
   open-pull-requests-limit: 20
+  ignore:
+    - dependency-name: TestContainers.Kafka

--- a/examples/ConsumeAndPublishWithKafka_IntegrationTest/ConsumeAndPublishWithKafka_IntegrationTest.csproj
+++ b/examples/ConsumeAndPublishWithKafka_IntegrationTest/ConsumeAndPublishWithKafka_IntegrationTest.csproj
@@ -9,7 +9,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0"/>
-        <PackageReference Include="TestContainers.Kafka" Version="4.4.0" />
+        <PackageReference Include="TestContainers.Kafka" Version="4.6.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5"/>
     </ItemGroup>

--- a/test/Motor.Extensions.Diagnostics.Telemetry_IntegrationTest/Motor.Extensions.Diagnostics.Telemetry_IntegrationTest.csproj
+++ b/test/Motor.Extensions.Diagnostics.Telemetry_IntegrationTest/Motor.Extensions.Diagnostics.Telemetry_IntegrationTest.csproj
@@ -13,7 +13,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="TestContainers" Version="4.7.0" />
+        <PackageReference Include="TestContainers" Version="4.6.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/test/Motor.Extensions.Hosting.Kafka_IntegrationTest/Motor.Extensions.Hosting.Kafka_IntegrationTest.csproj
+++ b/test/Motor.Extensions.Hosting.Kafka_IntegrationTest/Motor.Extensions.Hosting.Kafka_IntegrationTest.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="RandomDataGenerator.Net" Version="1.0.19.1" />
-        <PackageReference Include="TestContainers.Kafka" Version="4.7.0" />
+        <PackageReference Include="TestContainers.Kafka" Version="4.6.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
           <PrivateAssets>all</PrivateAssets>

--- a/test/Motor.Extensions.Hosting.NATS_IntegrationTest/Motor.Extensions.Hosting.NATS_IntegrationTest.csproj
+++ b/test/Motor.Extensions.Hosting.NATS_IntegrationTest/Motor.Extensions.Hosting.NATS_IntegrationTest.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="RandomDataGenerator.Net" Version="1.0.19.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
-        <PackageReference Include="TestContainers" Version="4.7.0" />
+        <PackageReference Include="TestContainers" Version="4.6.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/Motor.Extensions.Hosting.RabbitMQ_IntegrationTest/Motor.Extensions.Hosting.RabbitMQ_IntegrationTest.csproj
+++ b/test/Motor.Extensions.Hosting.RabbitMQ_IntegrationTest/Motor.Extensions.Hosting.RabbitMQ_IntegrationTest.csproj
@@ -10,7 +10,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="RandomDataGenerator.Net" Version="1.0.19.1" />
-        <PackageReference Include="TestContainers.RabbitMq" Version="4.7.0" />
+        <PackageReference Include="TestContainers.RabbitMq" Version="4.6.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
           <PrivateAssets>all</PrivateAssets>

--- a/test/Motor.Extensions.Hosting.SQS_IntegrationTest/Motor.Extensions.Hosting.SQS_IntegrationTest.csproj
+++ b/test/Motor.Extensions.Hosting.SQS_IntegrationTest/Motor.Extensions.Hosting.SQS_IntegrationTest.csproj
@@ -13,7 +13,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="RandomDataGenerator.Net" Version="1.0.19.1" />
-        <PackageReference Include="TestContainers" Version="4.7.0" />
+        <PackageReference Include="TestContainers" Version="4.6.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
The latest Testcontainers.Kafka version is causing issues with one of
our integration tests. I created #1375 to keep track of that issue.

For now, we'll have to stick with v4.6.0