### PR TITLE
Kafka performance improvments and bug fixes

### DIFF
--- a/src/Motor.Extensions.Hosting.Kafka/KafkaMessageConsumer.cs
+++ b/src/Motor.Extensions.Hosting.Kafka/KafkaMessageConsumer.cs
@@ -47,12 +47,17 @@ public sealed class KafkaMessageConsumer<TData> : IMessageConsumer<TData>, IDisp
         CloudEventFormatter cloudEventFormatter
     )
     {
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(config.Value);
+        ArgumentNullException.ThrowIfNull(applicationNameService);
+        ArgumentNullException.ThrowIfNull(cloudEventFormatter);
+
+        _logger = logger;
         _applicationLifetime = applicationLifetime;
-        _applicationNameService =
-            applicationNameService ?? throw new ArgumentNullException(nameof(applicationNameService));
+        _applicationNameService = applicationNameService;
         _cloudEventFormatter = cloudEventFormatter;
-        _options = config.Value ?? throw new ArgumentNullException(nameof(config));
+        _options = config.Value;
+
         _consumerLagSummary = metricsFactory?.CreateSummary(
             "consumer_lag_distribution",
             "Contains a summary of current consumer lag of each partition",

--- a/src/Motor.Extensions.Hosting.Kafka/KafkaMessageConsumer.cs
+++ b/src/Motor.Extensions.Hosting.Kafka/KafkaMessageConsumer.cs
@@ -168,21 +168,24 @@ public sealed class KafkaMessageConsumer<TData> : IMessageConsumer<TData>, IDisp
             case SyslogLevel.Alert:
             case SyslogLevel.Critical:
                 _logger.LogCritical(
-                    $"{logMessage.Message} -(Facility: {{facility}}, Name: {{name}})",
+                    "{Message} -(Facility: {Facility}, Name: {Name})",
+                    logMessage.Message,
                     logMessage.Facility,
                     logMessage.Name
                 );
                 break;
             case SyslogLevel.Error:
                 _logger.LogError(
-                    $"{logMessage.Message} -(Facility: {{facility}}, Name: {{name}})",
+                    "{Message} -(Facility: {Facility}, Name: {Name})",
+                    logMessage.Message,
                     logMessage.Facility,
                     logMessage.Name
                 );
                 break;
             case SyslogLevel.Warning:
                 _logger.LogWarning(
-                    $"{logMessage.Message} -(Facility: {{facility}}, Name: {{name}})",
+                    "{Message} -(Facility: {Facility}, Name: {Name})",
+                    logMessage.Message,
                     logMessage.Facility,
                     logMessage.Name
                 );
@@ -190,14 +193,16 @@ public sealed class KafkaMessageConsumer<TData> : IMessageConsumer<TData>, IDisp
             case SyslogLevel.Notice:
             case SyslogLevel.Info:
                 _logger.LogInformation(
-                    $"{logMessage.Message} -(Facility: {{facility}}, Name: {{name}})",
+                    "{Message} -(Facility: {Facility}, Name: {Name})",
+                    logMessage.Message,
                     logMessage.Facility,
                     logMessage.Name
                 );
                 break;
             case SyslogLevel.Debug:
                 _logger.LogDebug(
-                    $"{logMessage.Message} -(Facility: {{facility}}, Name: {{name}})",
+                    "{Message} -(Facility: {Facility}, Name: {Name})",
+                    logMessage.Message,
                     logMessage.Facility,
                     logMessage.Name
                 );
@@ -393,7 +398,7 @@ public sealed class KafkaMessageConsumer<TData> : IMessageConsumer<TData>, IDisp
             default:
                 _logger.LogCritical(
                     LogEvents.UnknownProcessedMessageStatus,
-                    "Unknown processed message status {status}",
+                    "Unknown processed message status {Status}",
                     status
                 );
                 return true;

--- a/src/Motor.Extensions.Hosting.Kafka/KafkaMessageConsumer.cs
+++ b/src/Motor.Extensions.Hosting.Kafka/KafkaMessageConsumer.cs
@@ -34,6 +34,7 @@ public sealed class KafkaMessageConsumer<TData> : IMessageConsumer<TData>, IDisp
     private readonly IMetricFamily<ISummary>? _consumerLagSummary;
     private readonly ILogger<KafkaMessageConsumer<TData>> _logger;
     private readonly IHostApplicationLifetime _applicationLifetime;
+    private readonly AsyncPolicy<ProcessedMessageStatus> _retryPolicy;
     private IConsumer<string?, byte[]>? _consumer;
     private readonly CancellationTokenSource _internalCts = new();
 
@@ -69,6 +70,13 @@ public sealed class KafkaMessageConsumer<TData> : IMessageConsumer<TData>, IDisp
             _options.MaxConcurrentMessages
         );
         _timer = new Timer(HandleCommitTimer);
+
+        _retryPolicy = Policy
+            .HandleResult<ProcessedMessageStatus>(status => status == ProcessedMessageStatus.TemporaryFailure)
+            .WaitAndRetryAsync(
+                _options.RetriesOnTemporaryFailure,
+                retryAttempt => _options.RetryBasePeriod * Math.Pow(2, retryAttempt)
+            );
     }
 
     public Func<
@@ -241,13 +249,7 @@ public sealed class KafkaMessageConsumer<TData> : IMessageConsumer<TData>, IDisp
             );
             var cloudEvent = KafkaMessageToCloudEvent(msg.Message);
 
-            var retryPolicy = Policy
-                .HandleResult<ProcessedMessageStatus>(status => status == ProcessedMessageStatus.TemporaryFailure)
-                .WaitAndRetryAsync(
-                    _options.RetriesOnTemporaryFailure,
-                    retryAttempt => _options.RetryBasePeriod * Math.Pow(2, retryAttempt)
-                );
-            var status = await retryPolicy.ExecuteAsync(
+            var status = await _retryPolicy.ExecuteAsync(
                 (cancellationToken) => ConsumeCallbackAsync!.Invoke(cloudEvent, cancellationToken),
                 token
             );

--- a/src/Motor.Extensions.Hosting.Kafka/KafkaMessageConsumer.cs
+++ b/src/Motor.Extensions.Hosting.Kafka/KafkaMessageConsumer.cs
@@ -274,6 +274,7 @@ public sealed class KafkaMessageConsumer<TData> : IMessageConsumer<TData>, IDisp
     private readonly Timer _timer;
     private readonly object _commitLock = new();
     private bool _pendingCommit;
+    private int _messagesSinceLastCommit;
 
     private async Task ExecuteCommitLoopAsync(CancellationToken cancellationToken)
     {
@@ -299,9 +300,12 @@ public sealed class KafkaMessageConsumer<TData> : IMessageConsumer<TData>, IDisp
                 {
                     _consumer?.StoreOffset(result.ConsumeResult);
                     _pendingCommit = true;
+                    _messagesSinceLastCommit++;
                 }
 
-                if ((result.ConsumeResult.Offset.Value + 1) % _options.CommitPeriod == 0)
+                // Use message count since last commit instead of offset-based check.
+                // This works correctly across multiple partitions with non-contiguous offsets.
+                if (_messagesSinceLastCommit >= _options.CommitPeriod)
                 {
                     Commit();
                     RestartCommitTimer();
@@ -340,6 +344,7 @@ public sealed class KafkaMessageConsumer<TData> : IMessageConsumer<TData>, IDisp
             }
 
             _pendingCommit = false;
+            _messagesSinceLastCommit = 0;
             try
             {
                 _consumer?.Commit();

--- a/src/Motor.Extensions.Hosting.Kafka/KafkaMessagePublisher.cs
+++ b/src/Motor.Extensions.Hosting.Kafka/KafkaMessagePublisher.cs
@@ -36,11 +36,43 @@ public class KafkaMessagePublisher<TOutput> : IRawMessagePublisher<TOutput>, IDi
         _producer = new ProducerBuilder<string?, byte[]>(_options).Build();
     }
 
-    public async Task PublishMessageAsync(MotorCloudEvent<byte[]> motorCloudEvent, CancellationToken token = default)
+    public Task PublishMessageAsync(MotorCloudEvent<byte[]> motorCloudEvent, CancellationToken token = default)
     {
         var topic = motorCloudEvent.GetKafkaTopic() ?? _options.Topic;
         var message = CloudEventToKafkaMessage(motorCloudEvent);
-        await _producer.ProduceAsync(topic, message, token);
+
+        // Use Produce with a TaskCompletionSource for pipelining instead of
+        // awaiting ProduceAsync per message. This allows librdkafka to batch
+        // multiple messages into a single broker request, significantly
+        // improving throughput.
+        var tcs = new TaskCompletionSource<DeliveryResult<string?, byte[]>>(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
+
+        try
+        {
+            _producer.Produce(
+                topic,
+                message,
+                deliveryReport =>
+                {
+                    if (deliveryReport.Error.IsError)
+                    {
+                        tcs.SetException(new ProduceException<string?, byte[]>(deliveryReport.Error, deliveryReport));
+                    }
+                    else
+                    {
+                        tcs.SetResult(deliveryReport);
+                    }
+                }
+            );
+        }
+        catch (ProduceException<string?, byte[]> ex)
+        {
+            tcs.SetException(ex);
+        }
+
+        return tcs.Task;
     }
 
     public Message<string?, byte[]> CloudEventToKafkaMessage(MotorCloudEvent<byte[]> motorCloudEvent)

--- a/src/Motor.Extensions.Hosting.Kafka/KafkaMessagePublisher.cs
+++ b/src/Motor.Extensions.Hosting.Kafka/KafkaMessagePublisher.cs
@@ -5,6 +5,7 @@ using CloudNative.CloudEvents;
 using CloudNative.CloudEvents.Extensions;
 using CloudNative.CloudEvents.Kafka;
 using Confluent.Kafka;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Motor.Extensions.Hosting.Abstractions;
 using Motor.Extensions.Hosting.CloudEvents;
@@ -19,16 +20,19 @@ public class KafkaMessagePublisher<TOutput> : IRawMessagePublisher<TOutput>, IDi
     private readonly IProducer<string?, byte[]> _producer;
     private readonly KafkaPublisherOptions<TOutput> _options;
     private readonly PublisherOptions _publisherOptions;
+    private readonly ILogger<KafkaMessagePublisher<TOutput>> _logger;
 
     public KafkaMessagePublisher(
         IOptions<KafkaPublisherOptions<TOutput>> options,
         CloudEventFormatter cloudEventFormatter,
-        IOptions<PublisherOptions> publisherOptions
+        IOptions<PublisherOptions> publisherOptions,
+        ILogger<KafkaMessagePublisher<TOutput>> logger
     )
     {
         _cloudEventFormatter = cloudEventFormatter;
         _options = options.Value ?? throw new ArgumentNullException(nameof(options));
         _publisherOptions = publisherOptions.Value ?? throw new ArgumentNullException(nameof(publisherOptions));
+        _logger = logger;
         _producer = new ProducerBuilder<string?, byte[]>(_options).Build();
     }
 
@@ -57,6 +61,14 @@ public class KafkaMessagePublisher<TOutput> : IRawMessagePublisher<TOutput>, IDi
 
     public void Dispose()
     {
+        try
+        {
+            _producer.Flush(TimeSpan.FromSeconds(10));
+        }
+        catch (Exception e)
+        {
+            _logger.LogWarning(e, "Error flushing producer during dispose");
+        }
         _producer.Dispose();
     }
 }

--- a/src/Motor.Extensions.Hosting.Kafka/LogEvents.cs
+++ b/src/Motor.Extensions.Hosting.Kafka/LogEvents.cs
@@ -14,7 +14,7 @@ public static class LogEvents
     public static readonly EventId UnknownProcessedMessageStatus = new(7, nameof(UnknownProcessedMessageStatus));
 
     public static readonly EventId MessageHandlingUnexpectedException = new(
-        7,
+        8,
         nameof(MessageHandlingUnexpectedException)
     );
 }

--- a/src/Motor.Extensions.Hosting.Kafka/Options/KafkaPublisherOptions.cs
+++ b/src/Motor.Extensions.Hosting.Kafka/Options/KafkaPublisherOptions.cs
@@ -4,5 +4,14 @@ namespace Motor.Extensions.Hosting.Kafka.Options;
 
 public class KafkaPublisherOptions<T> : ProducerConfig
 {
+    public KafkaPublisherOptions()
+    {
+        // Allow librdkafka to batch messages for better throughput.
+        // LingerMs controls how long to wait for additional messages before sending a batch.
+        LingerMs ??= 5;
+        // Enable Snappy compression for better network throughput with low CPU overhead.
+        CompressionType ??= Confluent.Kafka.CompressionType.Snappy;
+    }
+
     public string? Topic { get; set; }
 }

--- a/test/Motor.Extensions.Hosting.Kafka_IntegrationTest/KafkaExtensionTests.cs
+++ b/test/Motor.Extensions.Hosting.Kafka_IntegrationTest/KafkaExtensionTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using CloudNative.CloudEvents.SystemTextJson;
 using Confluent.Kafka;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using Motor.Extensions.Hosting.Abstractions;
@@ -519,7 +520,12 @@ public class KafkaExtensionTests(ITestOutputHelper output, KafkaFixture fixture)
     {
         var options = Options.Create(GetPublisherConfig<T>(topic));
         var publisherOptions = Options.Create(new PublisherOptions());
-        return new KafkaMessagePublisher<T>(options, new JsonEventFormatter(), publisherOptions);
+        return new KafkaMessagePublisher<T>(
+            options,
+            new JsonEventFormatter(),
+            publisherOptions,
+            Mock.Of<ILogger<KafkaMessagePublisher<T>>>()
+        );
     }
 
     private KafkaPublisherOptions<T> GetPublisherConfig<T>(string topic)

--- a/test/Motor.Extensions.Hosting.Kafka_UnitTest/KafkaMessageTests.cs
+++ b/test/Motor.Extensions.Hosting.Kafka_UnitTest/KafkaMessageTests.cs
@@ -96,7 +96,8 @@ public class KafkaMessageTests
         return new KafkaMessagePublisher<TData>(
             Options.Create(options),
             new JsonEventFormatter(),
-            Options.Create(new PublisherOptions { CloudEventFormat = format })
+            Options.Create(new PublisherOptions { CloudEventFormat = format }),
+            Mock.Of<ILogger<KafkaMessagePublisher<TData>>>()
         );
     }
 


### PR DESCRIPTION
### Motor.Extensions.Hosting.Kafka — Changelog

## Performance Improvements
- **Publisher**: Pipelined message production — Replaced synchronous ProduceAsync (one broker round-trip per message) with Produce + delivery report callback. This allows librdkafka to batch multiple messages into fewer broker requests, significantly improving publish throughput.
- **Publisher**: Sensible batching and compression defaults — KafkaPublisherOptions now defaults to LingerMs = 5 and CompressionType = Snappy for better out-of-the-box throughput. Both can still be overridden via configuration.
- **Consumer**: Eliminated per-message retry policy allocation — The Polly retry policy is now created once at startup and reused across all messages, reducing GC pressure under high load.

## Bug Fixes
- **Consumer**: Fixed unreliable offset-based commit period — Commit frequency was based on (offset + 1) % CommitPeriod, which behaves incorrectly with multiple partitions or non-contiguous offsets. Replaced with a processed-message counter that resets on each commit.
- **Publisher**: Flush on dispose — The producer now flushes buffered messages before disposing, preventing silent message loss on shutdown.
- **Fixed duplicate EventId** — UnknownProcessedMessageStatus and MessageHandlingUnexpectedException both used EventId 7. The latter is now 8.

## Code Quality
- **Fixed string interpolation** in log templates — Kafka log handler messages used $"..." interpolation in the log template string, causing string allocations even when the log level was disabled. Replaced with proper structured logging placeholders.