### PR TITLE
Fix dotnet version in dockerfile

### DIFF
--- a/src/Motor.Extensions.Hosting.Bridge/Dockerfile
+++ b/src/Motor.Extensions.Hosting.Bridge/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine
+FROM mcr.microsoft.com/dotnet/aspnet:9.0-alpine
 COPY . /data
 WORKDIR /data
 

--- a/src/Motor.Extensions.Hosting.Bridge/Dockerfile
+++ b/src/Motor.Extensions.Hosting.Bridge/Dockerfile
@@ -7,7 +7,7 @@ ENV DOTNET_ENVIRONMENT=$DOTNET_ENVIRONMENT
 
 HEALTHCHECK CMD wget --quiet --tries=1 --spider http://localhost:9110/health || exit 1
 
-ENTRYPOINT dotnet /data/Motor.Extensions.Hosting.Bridge.dll
+ENTRYPOINT ["dotnet", "/data/Motor.Extensions.Hosting.Bridge.dll"]
 
 LABEL org.opencontainers.image.title="Motor.NET Bridge Docker Image" \
       org.opencontainers.image.description="Motor.NET" \


### PR DESCRIPTION
My renovate wanted to update my motornet/bridge image to version v0.16.0, but after deployment I received "you must update .NET to run" errors because the image was built with dotnet 7 and the dll was built with a newer target framework.

I also adjusted the ENTRYPOINT so the build warning goes away.

```
You must install or update .NET to run this application.

App: /data/Motor.Extensions.Hosting.Bridge.dll
Architecture: x64
Framework: 'Microsoft.NETCore.App', version '9.0.0' (x64)
.NET location: /usr/share/dotnet/

The following frameworks were found:
  7.0.20 at [/usr/share/dotnet/shared/Microsoft.NETCore.App]

Learn about framework resolution:
https://aka.ms/dotnet/app-launch-failed

To install missing framework, download:
https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=9.0.0&arch=x64&rid=alpine.3.19-x64
```