### PR TITLE
Limit message sizes

### DIFF
--- a/src/Motor.Extensions.ContentEncoding.Abstractions/ContentEncodingOptions.cs
+++ b/src/Motor.Extensions.ContentEncoding.Abstractions/ContentEncodingOptions.cs
@@ -3,4 +3,5 @@ namespace Motor.Extensions.ContentEncoding.Abstractions;
 public record ContentEncodingOptions
 {
     public bool IgnoreEncoding { get; init; }
+    public long MaxMessageBytes { get; init; } = 100 * 1024 * 1024;
 }

--- a/src/Motor.Extensions.ContentEncoding.Abstractions/Motor.Extensions.ContentEncoding.Abstractions.csproj
+++ b/src/Motor.Extensions.ContentEncoding.Abstractions/Motor.Extensions.ContentEncoding.Abstractions.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <PackageReference Include="CloudNative.CloudEvents" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Motor.Extensions.Hosting.CloudEvents\Motor.Extensions.Hosting.CloudEvents.csproj" />

--- a/src/Motor.Extensions.ContentEncoding.Abstractions/NoOpMessageDecoder.cs
+++ b/src/Motor.Extensions.ContentEncoding.Abstractions/NoOpMessageDecoder.cs
@@ -1,14 +1,27 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
 
 namespace Motor.Extensions.ContentEncoding.Abstractions;
 
 public class NoOpMessageDecoder : IMessageDecoder
 {
+    private readonly ContentEncodingOptions _options;
+
+    public NoOpMessageDecoder(IOptions<ContentEncodingOptions> options)
+    {
+        _options = options.Value;
+    }
+
     public string Encoding => NoOpMessageEncoder.NoEncoding;
 
     public Task<byte[]> DecodeAsync(byte[] encodedMessage, CancellationToken cancellationToken)
     {
-        return Task.FromResult(encodedMessage);
+        return encodedMessage.Length > _options.MaxMessageBytes
+            ? throw new ArgumentException(
+                $"Message size {encodedMessage.Length} exceeds the maximum allowed size of {_options.MaxMessageBytes} bytes."
+            )
+            : Task.FromResult(encodedMessage);
     }
 }

--- a/src/Motor.Extensions.ContentEncoding.Gzip/GzipMessageDecoder.cs
+++ b/src/Motor.Extensions.ContentEncoding.Gzip/GzipMessageDecoder.cs
@@ -1,13 +1,22 @@
+using System;
 using System.IO;
 using System.IO.Compression;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
 using Motor.Extensions.ContentEncoding.Abstractions;
 
 namespace Motor.Extensions.ContentEncoding.Gzip;
 
 public class GzipMessageDecoder : IMessageDecoder
 {
+    private readonly ContentEncodingOptions _options;
+
+    public GzipMessageDecoder(IOptions<ContentEncodingOptions> options)
+    {
+        _options = options.Value;
+    }
+
     public string Encoding => GzipMessageEncoder.GzipEncoding;
 
     public async Task<byte[]> DecodeAsync(byte[] encodedMessage, CancellationToken cancellationToken)
@@ -15,9 +24,23 @@ public class GzipMessageDecoder : IMessageDecoder
         var compressedStream = new MemoryStream(encodedMessage);
 
         var output = new MemoryStream();
-        //use using with explicit scope to close/flush the GZipStream before using the outputstream
+        //use using with explicit scope to close/flush the GZipStream before using the output stream
         await using (var decompressionStream = new GZipStream(compressedStream, CompressionMode.Decompress))
         {
+            var buffer = new byte[64 * 1024];
+            var totalBytesRead = 0L;
+            int bytesRead;
+            while ((bytesRead = await decompressionStream.ReadAsync(buffer, cancellationToken)) > 0)
+            {
+                totalBytesRead += bytesRead;
+                if (totalBytesRead > _options.MaxMessageBytes)
+                {
+                    throw new ArgumentException(
+                        $"Decompressed Message size {encodedMessage.Length} exceeds the maximum allowed size of {_options.MaxMessageBytes} bytes."
+                    );
+                }
+                await output.WriteAsync(buffer, 0, bytesRead, cancellationToken);
+            }
             await decompressionStream.CopyToAsync(output, cancellationToken);
         }
 

--- a/test/Motor.Extensions.ContentEncoding.Abstractions_UnitTest/NoOpDecoderTests.cs
+++ b/test/Motor.Extensions.ContentEncoding.Abstractions_UnitTest/NoOpDecoderTests.cs
@@ -1,5 +1,6 @@
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
 using Motor.Extensions.ContentEncoding.Abstractions;
 using Xunit;
 
@@ -18,8 +19,19 @@ public class NoOpDecoderTests
         Assert.Equal(encoded, decoded);
     }
 
-    private static NoOpMessageDecoder CreateDecoder()
+    [Fact]
+    public async Task Decode_MessageTooLarge_ThrowsArgumentException()
     {
-        return new();
+        var decoder = CreateDecoder(new ContentEncodingOptions { MaxMessageBytes = 2 });
+        var encoded = new byte[] { 1, 2, 3 };
+
+        await Assert.ThrowsAsync<ArgumentException>(async () =>
+            await decoder.DecodeAsync(encoded, CancellationToken.None)
+        );
+    }
+
+    private static NoOpMessageDecoder CreateDecoder(ContentEncodingOptions? options = null)
+    {
+        return new(Options.Create(options ?? new ContentEncodingOptions()));
     }
 }

--- a/test/Motor.Extensions.ContentEncoding.Gzip_UnitTest/GzipMessageDecoderTests.cs
+++ b/test/Motor.Extensions.ContentEncoding.Gzip_UnitTest/GzipMessageDecoderTests.cs
@@ -2,6 +2,8 @@ using System.IO;
 using System.IO.Compression;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Motor.Extensions.ContentEncoding.Abstractions;
 using Motor.Extensions.ContentEncoding.Gzip;
 using Xunit;
 
@@ -21,9 +23,21 @@ public class GzipMessageDecoderTests
         Assert.Equal(decodedInput, decoded);
     }
 
-    private static GzipMessageDecoder CreateDecoder()
+    [Fact]
+    public async Task Decode_DecodedMessageTooLarge_ThrowsArgumentException()
     {
-        return new();
+        var decoder = CreateDecoder(new ContentEncodingOptions { MaxMessageBytes = 100 });
+        var decodedInput = new byte[1000];
+        var encoded = await EncodeAsync(decodedInput);
+
+        await Assert.ThrowsAsync<ArgumentException>(async () =>
+            await decoder.DecodeAsync(encoded, CancellationToken.None)
+        );
+    }
+
+    private static GzipMessageDecoder CreateDecoder(ContentEncodingOptions? options = null)
+    {
+        return new(Options.Create(options ?? new ContentEncodingOptions()));
     }
 
     private static async Task<byte[]> EncodeAsync(byte[] rawMessage)

--- a/test/Motor.Extensions.Hosting.Consumer_UnitTest/TypedConsumerServiceTests.cs
+++ b/test/Motor.Extensions.Hosting.Consumer_UnitTest/TypedConsumerServiceTests.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -49,6 +45,24 @@ public class TypedConsumerServiceTests
     }
 
     [Fact]
+    public async Task SingleMessageConsumeAsync_MessageTooLarge__InvalidInput()
+    {
+        var inputEvent = CreateMotorCloudEventWithEncoding("some-encoding", new byte[1000]);
+        var fakeDecoder = new Mock<IMessageDecoder>();
+        fakeDecoder.Setup(m => m.Encoding).Returns("some-encoding");
+        fakeDecoder
+            .Setup(m => m.DecodeAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ArgumentException("Message is too large"));
+        var fakeMessageConsumer = new Mock<IMessageConsumer<string>>();
+        fakeMessageConsumer.SetupProperty(p => p.ConsumeCallbackAsync);
+        CreateConsumerService(decoder: fakeDecoder.Object, consumer: fakeMessageConsumer.Object);
+
+        var actual = await fakeMessageConsumer.Object.ConsumeCallbackAsync?.Invoke(inputEvent, CancellationToken.None)!;
+
+        Assert.Equal(ProcessedMessageStatus.InvalidInput, actual);
+    }
+
+    [Fact]
     public async Task SingleMessageConsumeAsync_UnknownEncodingInInput__InvalidInput()
     {
         var inputEvent = CreateMotorCloudEventWithEncoding("unknown-encoding");
@@ -70,7 +84,7 @@ public class TypedConsumerServiceTests
         var fakeMessageConsumer = new Mock<IMessageConsumer<string>>();
         fakeMessageConsumer.SetupProperty(p => p.ConsumeCallbackAsync);
         CreateConsumerService(
-            decoder: new NoOpMessageDecoder(),
+            decoder: new NoOpMessageDecoder(Options.Create(new ContentEncodingOptions())),
             consumer: fakeMessageConsumer.Object,
             ignoreEncoding: true
         );


### PR DESCRIPTION
Messages with extremely large payloads may lead to OOM kills of Motor.NET applications. This is especially the case when gzip compression is used and the decompressed size of the message exceeds the compressed size by orders of magnitude.

This commit introduces a configurable maximum message size with a default value of 100MiB. If this limit is exceeded, an `ArgumentException` is thrown, which leads to an `InvalidInput` message status. Depending on the user's configuration, this either drops the message or routes it to a dead letter queue for manual inspection.