### PR TITLE
Handle race condition on pgmq extension init

### DIFF
--- a/src/Motor.Extensions.Hosting.PgMq/PgMqHostBuilderExtensions.cs
+++ b/src/Motor.Extensions.Hosting.PgMq/PgMqHostBuilderExtensions.cs
@@ -52,6 +52,7 @@ public static class PgMqHostBuilderExtensions
         builder.Configure<PgMqPublisherOptions>(config);
         builder.AddPublisher(sp => new PgMqMessageProducer<T>(
             MSOptions.Create(options),
+            sp.GetRequiredService<ILogger<PgMqMessageProducer<T>>>(),
             sp.GetRequiredService<IOptions<PublisherOptions>>(),
             new NpgmqClient(options.ToConnectionString())
         ));

--- a/src/Motor.Extensions.Hosting.PgMq/PgMqMessageConsumer.cs
+++ b/src/Motor.Extensions.Hosting.PgMq/PgMqMessageConsumer.cs
@@ -8,7 +8,6 @@ using Motor.Extensions.Hosting.Abstractions;
 using Motor.Extensions.Hosting.CloudEvents;
 using Motor.Extensions.Hosting.PgMq.Options;
 using Npgmq;
-using Npgsql;
 
 namespace Motor.Extensions.Hosting.PgMq;
 

--- a/src/Motor.Extensions.Hosting.PgMq/PgMqMessageConsumer.cs
+++ b/src/Motor.Extensions.Hosting.PgMq/PgMqMessageConsumer.cs
@@ -77,7 +77,24 @@ public sealed class PgMqMessageConsumer<TData> : IMessageConsumer<TData>
     /// </exception>
     public async Task StartAsync(CancellationToken token = default)
     {
-        await _npgmqClient.InitAsync(token);
+        try
+        {
+            await _npgmqClient.InitAsync(token);
+        }
+        catch (NpgmqException e)
+        {
+            // This is possibly a race with another extension initializing in parallel.
+            // Check if the extension is already present.
+            try
+            {
+                await _npgmqClient.GetPgmqVersionAsync(token);
+            }
+            catch (NpgmqException)
+            {
+                throw e;
+            }
+        }
+
         await _npgmqClient.CreateQueueAsync(_options.QueueName, token);
         _started = true;
     }

--- a/src/Motor.Extensions.Hosting.PgMq/PgMqMessageConsumer.cs
+++ b/src/Motor.Extensions.Hosting.PgMq/PgMqMessageConsumer.cs
@@ -8,6 +8,7 @@ using Motor.Extensions.Hosting.Abstractions;
 using Motor.Extensions.Hosting.CloudEvents;
 using Motor.Extensions.Hosting.PgMq.Options;
 using Npgmq;
+using Npgsql;
 
 namespace Motor.Extensions.Hosting.PgMq;
 
@@ -83,15 +84,13 @@ public sealed class PgMqMessageConsumer<TData> : IMessageConsumer<TData>
         }
         catch (NpgmqException e)
         {
-            // This is possibly a race with another extension initializing in parallel.
-            // Check if the extension is already present.
-            try
+            if (e.InnerException is PostgresException { SqlState: PostgresErrorCodes.UniqueViolation })
             {
-                await _npgmqClient.GetPgmqVersionAsync(token);
+                _logger.LogWarning(e, "pgmq extension already exists, assuming it was created by another instance");
             }
-            catch (NpgmqException)
+            else
             {
-                throw e;
+                throw;
             }
         }
 

--- a/src/Motor.Extensions.Hosting.PgMq/PgMqMessageConsumer.cs
+++ b/src/Motor.Extensions.Hosting.PgMq/PgMqMessageConsumer.cs
@@ -78,19 +78,24 @@ public sealed class PgMqMessageConsumer<TData> : IMessageConsumer<TData>
     /// </exception>
     public async Task StartAsync(CancellationToken token = default)
     {
-        try
+        var retry = 0;
+        while (true)
         {
-            await _npgmqClient.InitAsync(token);
-        }
-        catch (NpgmqException e)
-        {
-            if (e.InnerException is PostgresException { SqlState: PostgresErrorCodes.UniqueViolation })
+            try
             {
-                _logger.LogWarning(e, "pgmq extension already exists, assuming it was created by another instance");
+                await _npgmqClient.InitAsync(token);
+                break;
             }
-            else
+            catch (NpgmqException e)
             {
-                throw;
+                retry++;
+                if (retry > 5)
+                {
+                    _logger.LogError(e, "Failed to initialize Npgmq client after {RetryCount} attempts.", retry);
+                    throw;
+                }
+
+                await Task.Delay(TimeSpan.FromMilliseconds(100), cancellationToken: token);
             }
         }
 

--- a/src/Motor.Extensions.Hosting.PgMq/PgMqMessageProducer.cs
+++ b/src/Motor.Extensions.Hosting.PgMq/PgMqMessageProducer.cs
@@ -8,7 +8,6 @@ using Motor.Extensions.Hosting.Abstractions;
 using Motor.Extensions.Hosting.CloudEvents;
 using Motor.Extensions.Hosting.PgMq.Options;
 using Npgmq;
-using Npgsql;
 
 namespace Motor.Extensions.Hosting.PgMq;
 

--- a/src/Motor.Extensions.Hosting.PgMq/PgMqMessageProducer.cs
+++ b/src/Motor.Extensions.Hosting.PgMq/PgMqMessageProducer.cs
@@ -2,11 +2,13 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Motor.Extensions.Hosting.Abstractions;
 using Motor.Extensions.Hosting.CloudEvents;
 using Motor.Extensions.Hosting.PgMq.Options;
 using Npgmq;
+using Npgsql;
 
 namespace Motor.Extensions.Hosting.PgMq;
 
@@ -23,16 +25,19 @@ public class PgMqMessageProducer<TOutput> : IRawMessagePublisher<TOutput>
     where TOutput : notnull
 {
     private readonly PgMqPublisherOptions _options;
+    private readonly ILogger<PgMqMessageProducer<TOutput>> _logger;
     private readonly PublisherOptions _publisherOptions;
     private readonly INpgmqClient _npgmqClient;
 
     public PgMqMessageProducer(
         IOptions<PgMqPublisherOptions> options,
+        ILogger<PgMqMessageProducer<TOutput>> logger,
         IOptions<PublisherOptions> publisherOptions,
         INpgmqClient npgmqClient
     )
     {
         _options = options.Value;
+        _logger = logger;
         _publisherOptions = publisherOptions.Value;
         _npgmqClient = npgmqClient;
     }
@@ -62,15 +67,13 @@ public class PgMqMessageProducer<TOutput> : IRawMessagePublisher<TOutput>
         }
         catch (NpgmqException e)
         {
-            // This is possibly a race with another extension initializing in parallel.
-            // Check if the extension is already present.
-            try
+            if (e.InnerException is PostgresException { SqlState: PostgresErrorCodes.UniqueViolation })
             {
-                await _npgmqClient.GetPgmqVersionAsync(token);
+                _logger.LogWarning(e, "pgmq extension already exists, assuming it was created by another instance");
             }
-            catch (NpgmqException)
+            else
             {
-                throw e;
+                throw;
             }
         }
 

--- a/src/Motor.Extensions.Hosting.PgMq/PgMqMessageProducer.cs
+++ b/src/Motor.Extensions.Hosting.PgMq/PgMqMessageProducer.cs
@@ -61,19 +61,24 @@ public class PgMqMessageProducer<TOutput> : IRawMessagePublisher<TOutput>
     /// </remarks>
     public async Task StartAsync(CancellationToken token = default)
     {
-        try
+        var retry = 0;
+        while (true)
         {
-            await _npgmqClient.InitAsync(token);
-        }
-        catch (NpgmqException e)
-        {
-            if (e.InnerException is PostgresException { SqlState: PostgresErrorCodes.UniqueViolation })
+            try
             {
-                _logger.LogWarning(e, "pgmq extension already exists, assuming it was created by another instance");
+                await _npgmqClient.InitAsync(token);
+                break;
             }
-            else
+            catch (NpgmqException e)
             {
-                throw;
+                retry++;
+                if (retry > 5)
+                {
+                    _logger.LogError(e, "Failed to initialize Npgmq client after {RetryCount} attempts.", retry);
+                    throw;
+                }
+
+                await Task.Delay(TimeSpan.FromMilliseconds(100), cancellationToken: token);
             }
         }
 

--- a/src/Motor.Extensions.Hosting.PgMq/PgMqMessageProducer.cs
+++ b/src/Motor.Extensions.Hosting.PgMq/PgMqMessageProducer.cs
@@ -56,7 +56,24 @@ public class PgMqMessageProducer<TOutput> : IRawMessagePublisher<TOutput>
     /// </remarks>
     public async Task StartAsync(CancellationToken token = default)
     {
-        await _npgmqClient.InitAsync(token);
+        try
+        {
+            await _npgmqClient.InitAsync(token);
+        }
+        catch (NpgmqException e)
+        {
+            // This is possibly a race with another extension initializing in parallel.
+            // Check if the extension is already present.
+            try
+            {
+                await _npgmqClient.GetPgmqVersionAsync(token);
+            }
+            catch (NpgmqException)
+            {
+                throw e;
+            }
+        }
+
         await _npgmqClient.CreateQueueAsync(_options.QueueName, token);
     }
 

--- a/test/Motor.Extensions.Hosting.PgMq_IntegrationTest/PgMqIntegrationTests.cs
+++ b/test/Motor.Extensions.Hosting.PgMq_IntegrationTest/PgMqIntegrationTests.cs
@@ -320,7 +320,11 @@ public class PgMqIntegrationTests(PostgresFixture fixture) : IClassFixture<Postg
         Assert.NotNull(requeued);
     }
 
-    private PgMqMessageProducer<T> GetProducer<T>(string queueName, CloudEventFormat cloudEventFormat)
+    private PgMqMessageProducer<T> GetProducer<T>(
+        string queueName,
+        CloudEventFormat cloudEventFormat,
+        ILogger<PgMqMessageProducer<T>>? logger = null
+    )
         where T : notnull
     {
         var options = BuildPgOptions(
@@ -334,8 +338,10 @@ public class PgMqIntegrationTests(PostgresFixture fixture) : IClassFixture<Postg
             }
         );
         var producerOptions = MSOptions.Create(new PublisherOptions { CloudEventFormat = cloudEventFormat });
+        logger ??= Mock.Of<ILogger<PgMqMessageProducer<T>>>();
         return new PgMqMessageProducer<T>(
             MSOptions.Create(options),
+            logger,
             producerOptions,
             new NpgmqClient(options.ToConnectionString())
         );


### PR DESCRIPTION
This call can fail when multiple producers start in parallel. Try to recover from this gracefully if possible.