### PR TITLE
Allow using messaging functionality without MotorHostBuilder

### DIFF
--- a/examples/ConsumeAndPublishNATS/Program.cs
+++ b/examples/ConsumeAndPublishNATS/Program.cs
@@ -1,3 +1,4 @@
+using System;
 using ConsumeAndPublishNATS;
 using ConsumeAndPublishNATS.Model;
 using Microsoft.Extensions.DependencyInjection;
@@ -9,34 +10,70 @@ using Motor.Extensions.Hosting.NATS;
 using Motor.Extensions.Hosting.Publisher;
 using Motor.Extensions.Utilities;
 
-await MotorHost
-    .CreateDefaultBuilder()
+var useMotorHost = bool.Parse(Environment.GetEnvironmentVariable("USE_MOTOR_HOST") ?? "false");
+
+if (useMotorHost)
+{
+    await MotorHost
+        .CreateDefaultBuilder()
+        // Configure the types of the input and output messages
+        .ConfigureSingleOutputService<IncomingMessage, OutgoingMessage>()
+        .ConfigureServices(
+            (_, services) =>
+            {
+                // This handler is called for every new incoming message
+                services.AddTransient<ISingleOutputService<IncomingMessage, OutgoingMessage>, SingleOutputService>();
+            }
+        )
+        // Add the incoming communication module.
+        .ConfigureConsumer<IncomingMessage>(
+            (_, builder) =>
+            {
+                // In this case the messages are received from NATS
+                builder.AddNATS();
+                // The encoding of the incoming message, such that the handler is able to deserialize the message
+                builder.AddSystemJson();
+            }
+        )
+        .ConfigurePublisher<OutgoingMessage>(
+            (_, builder) =>
+            {
+                // In this case the messages are send to NATS
+                builder.AddNATS();
+                // The encoding of the outgoing message, such that the handler is able to serialize the message
+                builder.AddSystemJson();
+            }
+        )
+        .RunConsoleAsync();
+}
+else
+{
+    var builder = Host.CreateApplicationBuilder(args);
+
+    // Configure opinionated defaults for Motor applications, such as logging.
+    builder.AddMotorDefaults();
+
     // Configure the types of the input and output messages
-    .ConfigureSingleOutputService<IncomingMessage, OutgoingMessage>()
-    .ConfigureServices(
-        (_, services) =>
-        {
-            // This handler is called for every new incoming message
-            services.AddTransient<ISingleOutputService<IncomingMessage, OutgoingMessage>, SingleOutputService>();
-        }
-    )
+    builder.ConfigureSingleOutputService<IncomingMessage, OutgoingMessage>();
+
+    // This handler is called for every new incoming message
+    builder.Services.AddTransient<ISingleOutputService<IncomingMessage, OutgoingMessage>, SingleOutputService>();
+
     // Add the incoming communication module.
-    .ConfigureConsumer<IncomingMessage>(
-        (_, builder) =>
-        {
-            // In this case the messages are received from NATS
-            builder.AddNATS();
-            // The encoding of the incoming message, such that the handler is able to deserialize the message
-            builder.AddSystemJson();
-        }
-    )
-    .ConfigurePublisher<OutgoingMessage>(
-        (_, builder) =>
-        {
-            // In this case the messages are send to NATS
-            builder.AddNATS();
-            // The encoding of the outgoing message, such that the handler is able to serialize the message
-            builder.AddSystemJson();
-        }
-    )
-    .RunConsoleAsync();
+    builder
+        .AddConsumer<IncomingMessage>()
+        // In this case the messages are received from NATS
+        .AddNATS()
+        // The encoding of the incoming message, such that the handler is able to deserialize the message
+        .AddSystemJson();
+
+    // Add the outgoing communication module.
+    builder
+        .AddPublisher<OutgoingMessage>()
+        // In this case the messages are send to NATS
+        .AddNATS()
+        // The encoding of the outgoing message, such that the handler is able to serialize the message
+        .AddSystemJson();
+
+    await builder.Build().RunAsync();
+}

--- a/examples/ConsumeAndPublishWithKafka/Program.cs
+++ b/examples/ConsumeAndPublishWithKafka/Program.cs
@@ -1,3 +1,4 @@
+using System;
 using ConsumeAndPublishWithKafka;
 using ConsumeAndPublishWithKafka.Model;
 using Microsoft.Extensions.DependencyInjection;
@@ -9,39 +10,75 @@ using Motor.Extensions.Hosting.Kafka;
 using Motor.Extensions.Hosting.Publisher;
 using Motor.Extensions.Utilities;
 
-await MotorHost
-    .CreateDefaultBuilder()
+var useMotorHost = bool.Parse(Environment.GetEnvironmentVariable("USE_MOTOR_HOST") ?? "false");
+
+if (useMotorHost)
+{
+    await MotorHost
+        .CreateDefaultBuilder()
+        // Configure the types of the input and output messages
+        .ConfigureSingleOutputService<InputMessage, OutputMessage>()
+        .ConfigureServices(
+            (_, services) =>
+            {
+                // Add a handler for the input message which returns an output message
+                // This handler is called for every new incoming message
+                services.AddTransient<ISingleOutputService<InputMessage, OutputMessage>, SingleOutputService>();
+            }
+        )
+        // Add the incomming communication module.
+        .ConfigureConsumer<InputMessage>(
+            (_, builder) =>
+            {
+                // In this case the messages are received from Kafka
+                builder.AddKafka();
+                // The encoding of the incoming message, such that the handler is able to deserialize the message
+                builder.AddSystemJson();
+            }
+        )
+        // Add the outgoing communication module.
+        .ConfigurePublisher<OutputMessage>(
+            (_, builder) =>
+            {
+                // In this case the messages are send to Kafka
+                builder.AddKafka();
+                // The encoding of the outgoing message, such that the handler is able to serialize the message
+                builder.AddSystemJson();
+            }
+        )
+        .RunConsoleAsync();
+}
+else
+{
+    var builder = Host.CreateApplicationBuilder(args);
+
+    builder.AddMotorDefaults(assembly: typeof(Program).Assembly);
+
     // Configure the types of the input and output messages
-    .ConfigureSingleOutputService<InputMessage, OutputMessage>()
-    .ConfigureServices(
-        (_, services) =>
-        {
-            // Add a handler for the input message which returns an output message
-            // This handler is called for every new incoming message
-            services.AddTransient<ISingleOutputService<InputMessage, OutputMessage>, SingleOutputService>();
-        }
-    )
+    builder.ConfigureSingleOutputService<InputMessage, OutputMessage>();
+
+    // Add a handler for the input message which returns an output message
+    // This handler is called for every new incoming message
+    builder.Services.AddTransient<ISingleOutputService<InputMessage, OutputMessage>, SingleOutputService>();
+
     // Add the incomming communication module.
-    .ConfigureConsumer<InputMessage>(
-        (_, builder) =>
-        {
-            // In this case the messages are received from Kafka
-            builder.AddKafka();
-            // The encoding of the incoming message, such that the handler is able to deserialize the message
-            builder.AddSystemJson();
-        }
-    )
+    builder
+        .AddConsumer<InputMessage>()
+        // In this case the messages are received from Kafka
+        .AddKafka()
+        // The encoding of the incoming message, such that the handler is able to deserialize the message
+        .AddSystemJson();
+
     // Add the outgoing communication module.
-    .ConfigurePublisher<OutputMessage>(
-        (_, builder) =>
-        {
-            // In this case the messages are send to Kafka
-            builder.AddKafka();
-            // The encoding of the outgoing message, such that the handler is able to serialize the message
-            builder.AddSystemJson();
-        }
-    )
-    .RunConsoleAsync();
+    builder
+        .AddPublisher<OutputMessage>()
+        // In this case the messages are send to Kafka
+        .AddKafka()
+        // The encoding of the outgoing message, such that the handler is able to serialize the message
+        .AddSystemJson();
+
+    await builder.Build().RunAsync();
+}
 
 public partial class Program
 {

--- a/examples/ConsumeAndPublishWithKafka_IntegrationTest/SingleOutputServiceTest.cs
+++ b/examples/ConsumeAndPublishWithKafka_IntegrationTest/SingleOutputServiceTest.cs
@@ -1,5 +1,8 @@
 using Confluent.Kafka;
 using ConsumeAndPublishWithKafka.Model;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
 using Motor.Extensions.Hosting.Kafka.Options;
 using Motor.Extensions.TestUtilities;
 
@@ -13,6 +16,7 @@ public class SingleOutputServiceTest(KafkaFixture fixture) : IClassFixture<Kafka
     [Fact]
     public async Task EndToEnd_Test()
     {
+        Environment.SetEnvironmentVariable("USE_MOTOR_HOST", "true");
         const string testMessage = """{"FancyText": "Baz","FancyNumber": 1337}""";
         await fixture.CreateTopicAsync(ConsumedTopic);
         await fixture.CreateTopicAsync(PublishedTopic);
@@ -30,6 +34,42 @@ public class SingleOutputServiceTest(KafkaFixture fixture) : IClassFixture<Kafka
             })
             .Build();
         await testHost.WaitUntilHealthy();
+
+        await fixture.ProduceAsync(ConsumedTopic, testMessage);
+
+        const string expected = """{"NotSoFancyText":"zaB","NotSoFancyNumber":-1337}""";
+        var actual = consumer.Consume().Message.Value;
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public async Task EndToEnd_Test_NoMotorHost()
+    {
+        Environment.SetEnvironmentVariable("USE_MOTOR_HOST", "false");
+        const string testMessage = """{"FancyText": "Baz","FancyNumber": 1337}""";
+        await fixture.CreateTopicAsync(ConsumedTopic);
+        await fixture.CreateTopicAsync(PublishedTopic);
+        using var consumer = fixture.ConsumerFor(PublishedTopic);
+
+        await using var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.Configure(_ => { });
+            builder.ConfigureServices(services =>
+            {
+                services.Configure<KafkaConsumerOptions<InputMessage>>(o =>
+                {
+                    o.BootstrapServers = fixture.BootstrapServers;
+                    o.AutoOffsetReset = AutoOffsetReset.Earliest;
+                });
+
+                services.Configure<KafkaPublisherOptions<OutputMessage>>(o =>
+                {
+                    o.BootstrapServers = fixture.BootstrapServers;
+                });
+            });
+        });
+
+        factory.Server.AllowSynchronousIO = false;
 
         await fixture.ProduceAsync(ConsumedTopic, testMessage);
 

--- a/examples/ConsumeAndPublishWithPgMq/Program.cs
+++ b/examples/ConsumeAndPublishWithPgMq/Program.cs
@@ -8,25 +8,46 @@ using Motor.Extensions.Hosting.PgMq;
 using Motor.Extensions.Hosting.Publisher;
 using Motor.Extensions.Utilities;
 
-await MotorHost
-    .CreateDefaultBuilder()
-    .ConfigureSingleOutputService<InputMessage, OutputMessage>()
-    .ConfigureServices(
-        (_, services) =>
-        {
-            services.AddTransient<ISingleOutputService<InputMessage, OutputMessage>, SingleOutputService>();
-        }
-    )
-    .ConfigureConsumer<InputMessage>(
-        (_, builder) =>
-        {
-            builder.AddPgMq();
-        }
-    )
-    .ConfigurePublisher<OutputMessage>(
-        (_, builder) =>
-        {
-            builder.AddPgMq();
-        }
-    )
-    .RunConsoleAsync();
+var useMotorHost = bool.Parse(Environment.GetEnvironmentVariable("USE_MOTOR_HOST") ?? "false");
+
+if (useMotorHost)
+{
+    await MotorHost
+        .CreateDefaultBuilder()
+        .ConfigureSingleOutputService<InputMessage, OutputMessage>()
+        .ConfigureServices(
+            (_, services) =>
+            {
+                services.AddTransient<ISingleOutputService<InputMessage, OutputMessage>, SingleOutputService>();
+            }
+        )
+        .ConfigureConsumer<InputMessage>(
+            (_, builder) =>
+            {
+                builder.AddPgMq();
+            }
+        )
+        .ConfigurePublisher<OutputMessage>(
+            (_, builder) =>
+            {
+                builder.AddPgMq();
+            }
+        )
+        .RunConsoleAsync();
+}
+else
+{
+    var builder = Host.CreateApplicationBuilder(args);
+
+    // Configure opinionated defaults for Motor applications, such as logging.
+    builder.AddMotorDefaults();
+
+    builder.ConfigureSingleOutputService<InputMessage, OutputMessage>();
+    builder.Services.AddTransient<ISingleOutputService<InputMessage, OutputMessage>, SingleOutputService>();
+
+    builder.AddConsumer<InputMessage>().AddPgMq();
+
+    builder.AddPublisher<OutputMessage>().AddPgMq();
+
+    await builder.Build().RunAsync();
+}

--- a/examples/ConsumeAndPublishWithRabbitMQ/Program.cs
+++ b/examples/ConsumeAndPublishWithRabbitMQ/Program.cs
@@ -1,3 +1,4 @@
+using System;
 using ConsumeAndPublishWithRabbitMQ;
 using ConsumeAndPublishWithRabbitMQ.Model;
 using Microsoft.Extensions.DependencyInjection;
@@ -10,41 +11,83 @@ using Motor.Extensions.Hosting.Publisher;
 using Motor.Extensions.Hosting.RabbitMQ;
 using Motor.Extensions.Utilities;
 
-await MotorHost
-    .CreateDefaultBuilder()
+var useMotorHost = bool.Parse(Environment.GetEnvironmentVariable("USE_MOTOR_HOST") ?? "false");
+
+if (useMotorHost)
+{
+    await MotorHost
+        .CreateDefaultBuilder()
+        // Configure the types of the input and output messages
+        .ConfigureSingleOutputService<InputMessage, OutputMessage>()
+        .ConfigureServices(
+            (_, services) =>
+            {
+                // Add a handler for the input message which returns an output message
+                // This handler is called for every new incoming message
+                services.AddTransient<ISingleOutputService<InputMessage, OutputMessage>, SingleOutputService>();
+            }
+        )
+        // Add the incomming communication module.
+        .ConfigureConsumer<InputMessage>(
+            (_, builder) =>
+            {
+                // In this case the messages are received from RabbitMQ
+                builder.AddRabbitMQ();
+                // The encoding of the incoming message, such that the handler is able to deserialize the message
+                builder.AddSystemJson();
+                // (Optional) Enable support for incoming messages that are gzip compressed. Uncompressed messages will still
+                //  work to make the migration to compression backwards-compatible.
+                builder.AddGzipDecompression();
+            }
+        )
+        // Add the outgoing communication module.
+        .ConfigurePublisher<OutputMessage>(
+            (_, builder) =>
+            {
+                // In this case the messages are send to RabbitMQ
+                builder.AddRabbitMQ();
+                // The encoding of the outgoing message, such that the handler is able to serialize the message
+                builder.AddSystemJson();
+                // (Optional) Compress the serialized data of the outgoing message with gzip.
+                builder.AddGzipCompression();
+            }
+        )
+        .RunConsoleAsync();
+}
+else
+{
+    var builder = Host.CreateApplicationBuilder(args);
+
+    // Configure opinionated defaults for Motor applications, such as logging.
+    builder.AddMotorDefaults();
+
     // Configure the types of the input and output messages
-    .ConfigureSingleOutputService<InputMessage, OutputMessage>()
-    .ConfigureServices(
-        (_, services) =>
-        {
-            // Add a handler for the input message which returns an output message
-            // This handler is called for every new incoming message
-            services.AddTransient<ISingleOutputService<InputMessage, OutputMessage>, SingleOutputService>();
-        }
-    )
+    builder.ConfigureSingleOutputService<InputMessage, OutputMessage>();
+
+    // Add a handler for the input message which returns an output message
+    // This handler is called for every new incoming message
+    builder.Services.AddTransient<ISingleOutputService<InputMessage, OutputMessage>, SingleOutputService>();
+
     // Add the incomming communication module.
-    .ConfigureConsumer<InputMessage>(
-        (_, builder) =>
-        {
-            // In this case the messages are received from RabbitMQ
-            builder.AddRabbitMQ();
-            // The encoding of the incoming message, such that the handler is able to deserialize the message
-            builder.AddSystemJson();
-            // (Optional) Enable support for incoming messages that are gzip compressed. Uncompressed messages will still
-            //  work to make the migration to compression backwards-compatible.
-            builder.AddGzipDecompression();
-        }
-    )
+    builder
+        .AddConsumer<InputMessage>()
+        // In this case the messages are received from RabbitMQ
+        .AddRabbitMQ()
+        // The encoding of the incoming message, such that the handler is able to deserialize the message
+        .AddSystemJson()
+        // (Optional) Enable support for incoming messages that are gzip compressed. Uncompressed messages will still
+        //  work to make the migration to compression backwards-compatible.
+        .AddGzipDecompression();
+
     // Add the outgoing communication module.
-    .ConfigurePublisher<OutputMessage>(
-        (_, builder) =>
-        {
-            // In this case the messages are send to RabbitMQ
-            builder.AddRabbitMQ();
-            // The encoding of the outgoing message, such that the handler is able to serialize the message
-            builder.AddSystemJson();
-            // (Optional) Compress the serialized data of the outgoing message with gzip.
-            builder.AddGzipCompression();
-        }
-    )
-    .RunConsoleAsync();
+    builder
+        .AddPublisher<OutputMessage>()
+        // In this case the messages are send to RabbitMQ
+        .AddRabbitMQ()
+        // The encoding of the outgoing message, such that the handler is able to serialize the message
+        .AddSystemJson()
+        // (Optional) Compress the serialized data of the outgoing message with gzip.
+        .AddGzipCompression();
+
+    await builder.Build().RunAsync();
+}

--- a/examples/ConsumeSQS/Program.cs
+++ b/examples/ConsumeSQS/Program.cs
@@ -1,3 +1,4 @@
+using System;
 using ConsumeSQS;
 using ConsumeSQS.Model;
 using Microsoft.Extensions.DependencyInjection;
@@ -8,25 +9,53 @@ using Motor.Extensions.Hosting.Consumer;
 using Motor.Extensions.Hosting.SQS;
 using Motor.Extensions.Utilities;
 
-await MotorHost
-    .CreateDefaultBuilder()
+var useMotorHost = bool.Parse(Environment.GetEnvironmentVariable("USE_MOTOR_HOST") ?? "false");
+
+if (useMotorHost)
+{
+    await MotorHost
+        .CreateDefaultBuilder()
+        // Configure the types of the input messages
+        .ConfigureNoOutputService<InputMessage>()
+        .ConfigureServices(
+            (_, services) =>
+            {
+                // This handler is called for every new incoming message
+                services.AddTransient<INoOutputService<InputMessage>, NoOutputService>();
+            }
+        )
+        // Add the incoming communication module.
+        .ConfigureConsumer<InputMessage>(
+            (_, builder) =>
+            {
+                // In this case the messages are received from AWS SQS
+                builder.AddSQS();
+                // The encoding of the incoming message, such that the handler is able to deserialize the message
+                builder.AddSystemJson();
+            }
+        )
+        .RunConsoleAsync();
+}
+else
+{
+    var builder = Host.CreateApplicationBuilder(args);
+
+    // Configure opinionated defaults for Motor applications, such as logging.
+    builder.AddMotorDefaults();
+
     // Configure the types of the input messages
-    .ConfigureNoOutputService<InputMessage>()
-    .ConfigureServices(
-        (_, services) =>
-        {
-            // This handler is called for every new incoming message
-            services.AddTransient<INoOutputService<InputMessage>, NoOutputService>();
-        }
-    )
+    builder.ConfigureNoOutputService<InputMessage>();
+
+    // This handler is called for every new incoming message
+    builder.Services.AddTransient<INoOutputService<InputMessage>, NoOutputService>();
+
     // Add the incoming communication module.
-    .ConfigureConsumer<InputMessage>(
-        (_, builder) =>
-        {
-            // In this case the messages are received from AWS SQS
-            builder.AddSQS();
-            // The encoding of the incoming message, such that the handler is able to deserialize the message
-            builder.AddSystemJson();
-        }
-    )
-    .RunConsoleAsync();
+    builder
+        .AddConsumer<InputMessage>()
+        // In this case the messages are received from AWS SQS
+        .AddSQS()
+        // The encoding of the incoming message, such that the handler is able to deserialize the message
+        .AddSystemJson();
+
+    await builder.Build().RunAsync();
+}

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Version>0.18.2</Version>
     <TargetFrameworks>net8.0;net9.0;</TargetFrameworks>
-    <LangVersion>11</LangVersion>
+    <LangVersion>14</LangVersion>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>CS8600;CS8602;CS8625;CS8618;CS8604;CS8601</WarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>

--- a/src/Motor.Extensions.ContentEncoding.Abstractions/EncodingExtension.cs
+++ b/src/Motor.Extensions.ContentEncoding.Abstractions/EncodingExtension.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using CloudNative.CloudEvents;
 using CloudNative.CloudEvents.Core;
 using Motor.Extensions.Hosting.CloudEvents;
@@ -11,8 +10,7 @@ public static class EncodingExtension
     public static CloudEventAttribute EncodingAttribute { get; } =
         CloudEventAttribute.CreateExtension("contentencoding", CloudEventAttributeType.String);
 
-    public static IEnumerable<CloudEventAttribute> AllAttributes { get; } =
-        new[] { EncodingAttribute }.ToList().AsReadOnly();
+    public static IReadOnlyList<CloudEventAttribute> AllAttributes { get; } = [EncodingAttribute];
 
     public static MotorCloudEvent<TData> SetEncoding<TData>(this MotorCloudEvent<TData> cloudEvent, string? value)
         where TData : class

--- a/src/Motor.Extensions.Conversion.JsonNet/JsonNetHostBuilderExtensions.cs
+++ b/src/Motor.Extensions.Conversion.JsonNet/JsonNetHostBuilderExtensions.cs
@@ -4,17 +4,23 @@ namespace Motor.Extensions.Conversion.JsonNet;
 
 public static class JsonNetHostBuilderExtensions
 {
-    public static IPublisherBuilder<TOut> AddJsonNet<TOut>(this IPublisherBuilder<TOut> hostBuilder)
+    extension<TOut>(IPublisherBuilder<TOut> builder)
         where TOut : notnull
     {
-        hostBuilder.AddSerializer<JsonNetSerializer<TOut>>();
-        return hostBuilder;
+        public IPublisherBuilder<TOut> AddJsonNet()
+        {
+            builder.AddSerializer<JsonNetSerializer<TOut>>();
+            return builder;
+        }
     }
 
-    public static IConsumerBuilder<TIn> AddJsonNet<TIn>(this IConsumerBuilder<TIn> consumerBuilder)
+    extension<TIn>(IConsumerBuilder<TIn> builder)
         where TIn : notnull
     {
-        consumerBuilder.AddDeserializer<JsonNetDeserializer<TIn>>();
-        return consumerBuilder;
+        public IConsumerBuilder<TIn> AddJsonNet()
+        {
+            builder.AddDeserializer<JsonNetDeserializer<TIn>>();
+            return builder;
+        }
     }
 }

--- a/src/Motor.Extensions.Diagnostics.Logging/DefaultHostBuilderExtensions.cs
+++ b/src/Motor.Extensions.Diagnostics.Logging/DefaultHostBuilderExtensions.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Motor.Extensions.Diagnostics.Sentry;
-using Motor.Extensions.Utilities.Abstractions;
 using Sentry.Serilog;
 using Serilog;
 using Serilog.Formatting.Json;
@@ -12,13 +11,40 @@ namespace Motor.Extensions.Diagnostics.Logging;
 
 public static class DefaultHostBuilderExtensions
 {
-    public static IMotorHostBuilder ConfigureSerilog(
-        this IMotorHostBuilder hostBuilder,
-        Action<HostBuilderContext, LoggerConfiguration>? configuration = null
-    )
+    extension(IHostApplicationBuilder builder)
     {
-        return (IMotorHostBuilder)
-            hostBuilder
+        public IHostApplicationBuilder ConfigureMotorLogging()
+        {
+            builder.ConfigureSentry();
+
+            var sentryOptions =
+                builder.Configuration.GetSection("Sentry").Get<SentrySerilogOptions>() ?? new SentrySerilogOptions();
+
+            builder.Services.AddSerilog(
+                (_, loggerConfiguration) =>
+                {
+                    loggerConfiguration
+                        .ReadFrom.Configuration(builder.Configuration)
+                        .Enrich.FromLogContext()
+                        .WriteTo.Console(new JsonFormatter(renderMessage: true))
+                        .WriteTo.Sentry(opts =>
+                        {
+                            opts.Dsn = sentryOptions.Dsn;
+                            opts.MinimumEventLevel = sentryOptions.MinimumEventLevel;
+                            opts.MinimumBreadcrumbLevel = sentryOptions.MinimumBreadcrumbLevel;
+                            opts.InitializeSdk = false;
+                        });
+                }
+            );
+
+            return builder;
+        }
+    }
+
+    extension(IHostBuilder builder)
+    {
+        public IHostBuilder ConfigureSerilog(Action<HostBuilderContext, LoggerConfiguration>? configuration = null) =>
+            builder
                 .ConfigureSentry()
                 .UseSerilog(
                     (hostingContext, loggerConfiguration) =>

--- a/src/Motor.Extensions.Diagnostics.Metrics/PrometheusHostBuilderExtensions.cs
+++ b/src/Motor.Extensions.Diagnostics.Metrics/PrometheusHostBuilderExtensions.cs
@@ -1,33 +1,44 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Motor.Extensions.Diagnostics.Metrics.Abstractions;
-using Motor.Extensions.Utilities.Abstractions;
 using Prometheus.Client.AspNetCore;
 
 namespace Motor.Extensions.Diagnostics.Metrics;
 
 public static class PrometheusHostBuilderExtensions
 {
-    public static IMotorHostBuilder ConfigurePrometheus(this IMotorHostBuilder hostBuilder)
+    extension(IHostBuilder builder)
     {
-        hostBuilder.ConfigureServices(
-            (_, services) =>
-            {
-                services.AddSingleton(typeof(IMetricsFactory<>), typeof(MetricsFactory<>));
-                services.AddSingleton<IMotorMetricsFactory, MotorMetricsFactory>();
-            }
-        );
-        return hostBuilder;
+        public IHostBuilder ConfigurePrometheus()
+        {
+            builder.ConfigureServices(
+                (_, services) =>
+                {
+                    services.AddSingleton(typeof(IMetricsFactory<>), typeof(MetricsFactory<>));
+                    services.AddSingleton<IMotorMetricsFactory, MotorMetricsFactory>();
+                }
+            );
+            return builder;
+        }
     }
 
-    public static IApplicationBuilder UsePrometheusServer(
-        this IApplicationBuilder applicationBuilder,
-        bool useDefaultCollectors = true
-    )
+    extension(IHostApplicationBuilder builder)
     {
-        return applicationBuilder.UsePrometheusServer(prometheusOptions =>
+        public IHostApplicationBuilder ConfigurePrometheus()
         {
-            prometheusOptions.UseDefaultCollectors = useDefaultCollectors;
-        });
+            builder.Services.AddSingleton(typeof(IMetricsFactory<>), typeof(MetricsFactory<>));
+            builder.Services.AddSingleton<IMotorMetricsFactory, MotorMetricsFactory>();
+            return builder;
+        }
+    }
+
+    extension(IApplicationBuilder applicationBuilder)
+    {
+        public IApplicationBuilder UsePrometheusServer(bool useDefaultCollectors = true) =>
+            applicationBuilder.UsePrometheusServer(prometheusOptions =>
+            {
+                prometheusOptions.UseDefaultCollectors = useDefaultCollectors;
+            });
     }
 }

--- a/src/Motor.Extensions.Diagnostics.Sentry/DefaultHostBuilderExtensions.cs
+++ b/src/Motor.Extensions.Diagnostics.Sentry/DefaultHostBuilderExtensions.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
-using Motor.Extensions.Utilities.Abstractions;
 using Sentry;
 using Sentry.Serilog;
 using MSOptions = Microsoft.Extensions.Options.Options;
@@ -10,17 +10,32 @@ namespace Motor.Extensions.Diagnostics.Sentry;
 
 public static class DefaultHostBuilderExtensions
 {
-    public static IMotorHostBuilder ConfigureSentry(this IMotorHostBuilder hostBuilder)
+    extension(IHostApplicationBuilder builder)
     {
-        return hostBuilder.ConfigureServices(
-            (context, services) =>
-            {
-                var sentryOptions = new SentrySerilogOptions();
-                context.Configuration.GetSection("Sentry").Bind(sentryOptions);
-                sentryOptions.Dsn ??= string.Empty;
-                SentrySdk.Init(sentryOptions);
-                services.AddTransient<IOptions<SentrySerilogOptions>>(_ => MSOptions.Create(sentryOptions));
-            }
-        );
+        public IHostApplicationBuilder ConfigureSentry()
+        {
+            var sentryOptions = new SentrySerilogOptions();
+            builder.Configuration.GetSection("Sentry").Bind(sentryOptions);
+            sentryOptions.Dsn ??= string.Empty;
+            SentrySdk.Init(sentryOptions);
+            builder.Services.AddTransient<IOptions<SentrySerilogOptions>>(_ => MSOptions.Create(sentryOptions));
+
+            return builder;
+        }
+    }
+
+    extension(IHostBuilder builder)
+    {
+        public IHostBuilder ConfigureSentry() =>
+            builder.ConfigureServices(
+                (context, services) =>
+                {
+                    var sentryOptions = new SentrySerilogOptions();
+                    context.Configuration.GetSection("Sentry").Bind(sentryOptions);
+                    sentryOptions.Dsn ??= string.Empty;
+                    SentrySdk.Init(sentryOptions);
+                    services.AddTransient<IOptions<SentrySerilogOptions>>(_ => MSOptions.Create(sentryOptions));
+                }
+            );
     }
 }

--- a/src/Motor.Extensions.Diagnostics.Telemetry/DistributedTracingExtensionExtensions.cs
+++ b/src/Motor.Extensions.Diagnostics.Telemetry/DistributedTracingExtensionExtensions.cs
@@ -18,25 +18,27 @@ public static class DistributedTracingExtension
     public static IEnumerable<CloudEventAttribute> AllAttributes { get; } =
         new[] { TraceParentAttribute, TraceStateAttribute }.ToList().AsReadOnly();
 
-    public static void SetActivity<TData>(this MotorCloudEvent<TData> cloudEvent, Activity activity)
-        where TData : class
+    extension<TData>(MotorCloudEvent<TData> cloudEvent)
     {
-        Validation.CheckNotNull(cloudEvent, nameof(cloudEvent));
-        cloudEvent[TraceParentAttribute] = activity.Id;
-        if (!string.IsNullOrWhiteSpace(activity.TraceStateString))
+        public void SetActivity(Activity activity)
         {
-            cloudEvent[TraceStateAttribute] = activity.TraceStateString;
+            Validation.CheckNotNull(cloudEvent, nameof(cloudEvent));
+            cloudEvent[TraceParentAttribute] = activity.Id;
+            if (!string.IsNullOrWhiteSpace(activity.TraceStateString))
+            {
+                cloudEvent[TraceStateAttribute] = activity.TraceStateString;
+            }
         }
-    }
 
-    public static ActivityContext GetActivityContext<TData>(this MotorCloudEvent<TData> extension)
-        where TData : class
-    {
-        if (extension[TraceParentAttribute] is not string traceParent)
+        public ActivityContext GetActivityContext()
         {
-            return default;
+            if (cloudEvent[TraceParentAttribute] is not string traceParent)
+            {
+                return default;
+            }
+
+            var traceState = cloudEvent[TraceStateAttribute] as string;
+            return ActivityContext.Parse(traceParent, traceState);
         }
-        var traceState = extension[TraceStateAttribute] as string;
-        return ActivityContext.Parse(traceParent, traceState);
     }
 }

--- a/src/Motor.Extensions.Diagnostics.Telemetry/LegacyTelemetryHostBuilderExtensions.cs
+++ b/src/Motor.Extensions.Diagnostics.Telemetry/LegacyTelemetryHostBuilderExtensions.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Motor.Extensions.Hosting.CloudEvents;
+using OpenTelemetry.Exporter;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+namespace Motor.Extensions.Diagnostics.Telemetry;
+
+public static class LegacyTelemetryHostBuilderExtensions
+{
+    extension(IHostBuilder builder)
+    {
+        public IHostBuilder ConfigureOpenTelemetry()
+        {
+            Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+            Activity.ForceDefaultIdFormat = true;
+            builder.ConfigureServices(
+                (hostContext, services) =>
+                {
+                    UsedExporter? usedExport;
+                    if (hostContext.Configuration.GetSection(TelemetryHostBuilderExtensions.OtlpExporter).Exists())
+                    {
+                        services.Configure<OtlpExporterOptions>(
+                            hostContext.Configuration.GetSection(TelemetryHostBuilderExtensions.OtlpExporter)
+                        );
+                        usedExport = UsedExporter.Otlp;
+                    }
+                    else
+                    {
+                        services.Configure<JaegerExporterOptions>(
+                            hostContext.Configuration.GetSection(TelemetryHostBuilderExtensions.JaegerExporter)
+                        );
+                        usedExport = UsedExporter.Jaeger;
+                    }
+
+                    var telemetryOptions = new OpenTelemetryOptions();
+                    hostContext
+                        .Configuration.GetSection(TelemetryHostBuilderExtensions.OpenTelemetry)
+                        .Bind(telemetryOptions);
+                    services.AddSingleton(telemetryOptions);
+                    services
+                        .AddOpenTelemetry()
+                        .WithTracing(builder =>
+                        {
+                            builder
+                                .AddAspNetCoreInstrumentation(options =>
+                                {
+                                    options.Filter = TelemetryRequestFilter(telemetryOptions);
+                                })
+                                .AddSource(OpenTelemetryOptions.DefaultActivitySourceName)
+                                .AddSource(telemetryOptions.Sources.ToArray())
+                                .SetMotorSampler(telemetryOptions)
+                                .AddExporter(usedExport);
+                            if (builder is IDeferredTracerProviderBuilder deferredTracerProviderBuilder)
+                            {
+                                deferredTracerProviderBuilder.Configure(
+                                    (provider, providerBuilder) =>
+                                    {
+                                        providerBuilder.ConfigureResource(resourceBuilder =>
+                                        {
+                                            var applicationNameService =
+                                                provider.GetRequiredService<IApplicationNameService>();
+                                            resourceBuilder
+                                                .AddAttributes(
+                                                    new Dictionary<string, object>
+                                                    {
+                                                        {
+                                                            TelemetryHostBuilderExtensions.AttributeMotorNetEnvironment,
+                                                            hostContext.HostingEnvironment.EnvironmentName.ToLower()
+                                                        },
+                                                        {
+                                                            TelemetryHostBuilderExtensions.AttributeMotorNetLibraryVersion,
+                                                            applicationNameService.GetLibVersion()
+                                                        },
+                                                    }
+                                                )
+                                                .AddService(
+                                                    applicationNameService.GetFullName(),
+                                                    serviceVersion: applicationNameService.GetVersion()
+                                                );
+                                        });
+                                    }
+                                );
+                            }
+                        });
+                }
+            );
+            return builder;
+        }
+    }
+
+    private static Func<HttpContext, bool> TelemetryRequestFilter(OpenTelemetryOptions openTelemetryOptions) =>
+        req =>
+            !openTelemetryOptions.FilterOutTelemetryRequests
+            || !req.Request.Path.StartsWithSegments("/metrics") && !req.Request.Path.StartsWithSegments("/health");
+
+    private static TracerProviderBuilder SetMotorSampler(
+        this TracerProviderBuilder builder,
+        OpenTelemetryOptions options
+    )
+    {
+        Sampler sampler = options.SamplingProbability switch
+        {
+            >= 1 => new AlwaysOnSampler(),
+            _ => new TraceIdRatioBasedSampler(options.SamplingProbability),
+        };
+
+        builder.SetSampler(new ParentBasedSampler(sampler));
+        return builder;
+    }
+
+    private static void AddExporter(this TracerProviderBuilder builder, UsedExporter? exporter)
+    {
+        switch (exporter)
+        {
+            case UsedExporter.Otlp:
+                builder.AddOtlpExporter();
+                break;
+            case UsedExporter.Jaeger:
+                builder.AddJaegerExporter();
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(exporter), exporter, null);
+        }
+    }
+}

--- a/src/Motor.Extensions.Diagnostics.Telemetry/TelemetryHostBuilderExtensions.cs
+++ b/src/Motor.Extensions.Diagnostics.Telemetry/TelemetryHostBuilderExtensions.cs
@@ -4,8 +4,8 @@ using System.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Motor.Extensions.Hosting.CloudEvents;
-using Motor.Extensions.Utilities.Abstractions;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
@@ -20,82 +20,77 @@ public static class TelemetryHostBuilderExtensions
     public static readonly string AttributeMotorNetEnvironment = "motor.net.environment";
     public static readonly string AttributeMotorNetLibraryVersion = "motor.net.libversion";
 
-    private enum UsedExporter
+    extension(IHostApplicationBuilder hostBuilder)
     {
-        Oltp,
-        Jaeger,
-    }
+        public IHostApplicationBuilder ConfigureMotorTelemetry()
+        {
+            Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+            Activity.ForceDefaultIdFormat = true;
 
-    public static IMotorHostBuilder ConfigureOpenTelemetry(this IMotorHostBuilder hostBuilder)
-    {
-        Activity.DefaultIdFormat = ActivityIdFormat.W3C;
-        Activity.ForceDefaultIdFormat = true;
-        hostBuilder.ConfigureServices(
-            (hostContext, services) =>
+            UsedExporter? usedExport;
+            if (hostBuilder.Configuration.GetSection(OtlpExporter).Exists())
             {
-                UsedExporter? usedExport;
-                if (hostContext.Configuration.GetSection(OtlpExporter).Exists())
-                {
-                    services.Configure<OtlpExporterOptions>(hostContext.Configuration.GetSection(OtlpExporter));
-                    usedExport = UsedExporter.Oltp;
-                }
-                else
-                {
-                    services.Configure<JaegerExporterOptions>(hostContext.Configuration.GetSection(JaegerExporter));
-                    usedExport = UsedExporter.Jaeger;
-                }
-
-                var telemetryOptions = new OpenTelemetryOptions();
-                hostContext.Configuration.GetSection(OpenTelemetry).Bind(telemetryOptions);
-                services.AddSingleton(telemetryOptions);
-                services
-                    .AddOpenTelemetry()
-                    .WithTracing(builder =>
-                    {
-                        builder
-                            .AddAspNetCoreInstrumentation(options =>
-                            {
-                                options.Filter = TelemetryRequestFilter(telemetryOptions);
-                            })
-                            .AddSource(OpenTelemetryOptions.DefaultActivitySourceName)
-                            .AddSource(telemetryOptions.Sources.ToArray())
-                            .SetMotorSampler(telemetryOptions)
-                            .AddExporter(usedExport);
-                        if (builder is IDeferredTracerProviderBuilder deferredTracerProviderBuilder)
-                        {
-                            deferredTracerProviderBuilder.Configure(
-                                (provider, providerBuilder) =>
-                                {
-                                    providerBuilder.ConfigureResource(resourceBuilder =>
-                                    {
-                                        var applicationNameService =
-                                            provider.GetRequiredService<IApplicationNameService>();
-                                        resourceBuilder
-                                            .AddAttributes(
-                                                new Dictionary<string, object>
-                                                {
-                                                    {
-                                                        AttributeMotorNetEnvironment,
-                                                        hostContext.HostingEnvironment.EnvironmentName.ToLower()
-                                                    },
-                                                    {
-                                                        AttributeMotorNetLibraryVersion,
-                                                        applicationNameService.GetLibVersion()
-                                                    },
-                                                }
-                                            )
-                                            .AddService(
-                                                applicationNameService.GetFullName(),
-                                                serviceVersion: applicationNameService.GetVersion()
-                                            );
-                                    });
-                                }
-                            );
-                        }
-                    });
+                hostBuilder.Services.Configure<OtlpExporterOptions>(hostBuilder.Configuration.GetSection(OtlpExporter));
+                usedExport = UsedExporter.Otlp;
             }
-        );
-        return hostBuilder;
+            else
+            {
+                hostBuilder.Services.Configure<JaegerExporterOptions>(
+                    hostBuilder.Configuration.GetSection(JaegerExporter)
+                );
+                usedExport = UsedExporter.Jaeger;
+            }
+
+            var telemetryOptions = new OpenTelemetryOptions();
+            hostBuilder.Configuration.GetSection(OpenTelemetry).Bind(telemetryOptions);
+            hostBuilder.Services.AddSingleton(telemetryOptions);
+            hostBuilder
+                .Services.AddOpenTelemetry()
+                .WithTracing(builder =>
+                {
+                    builder
+                        .AddAspNetCoreInstrumentation(options =>
+                        {
+                            options.Filter = TelemetryRequestFilter(telemetryOptions);
+                        })
+                        .AddSource(OpenTelemetryOptions.DefaultActivitySourceName)
+                        .AddSource(telemetryOptions.Sources.ToArray())
+                        .SetMotorSampler(telemetryOptions)
+                        .AddExporter(usedExport);
+                    if (builder is IDeferredTracerProviderBuilder deferredTracerProviderBuilder)
+                    {
+                        deferredTracerProviderBuilder.Configure(
+                            (provider, providerBuilder) =>
+                            {
+                                providerBuilder.ConfigureResource(resourceBuilder =>
+                                {
+                                    var applicationNameService = provider.GetRequiredService<IApplicationNameService>();
+                                    resourceBuilder
+                                        .AddAttributes(
+                                            new Dictionary<string, object>
+                                            {
+                                                {
+                                                    AttributeMotorNetEnvironment,
+                                                    hostBuilder.Environment.EnvironmentName.ToLower()
+                                                },
+                                                {
+                                                    AttributeMotorNetLibraryVersion,
+                                                    applicationNameService.GetLibVersion()
+                                                },
+                                            }
+                                        )
+                                        .AddService(
+                                            applicationNameService.GetFullName(),
+                                            serviceVersion: applicationNameService.GetVersion()
+                                        );
+                                });
+                            }
+                        );
+                    }
+                });
+
+            return hostBuilder;
+        }
     }
 
     private static Func<HttpContext, bool> TelemetryRequestFilter(OpenTelemetryOptions openTelemetryOptions) =>
@@ -122,7 +117,7 @@ public static class TelemetryHostBuilderExtensions
     {
         switch (exporter)
         {
-            case UsedExporter.Oltp:
+            case UsedExporter.Otlp:
                 builder.AddOtlpExporter();
                 break;
             case UsedExporter.Jaeger:

--- a/src/Motor.Extensions.Diagnostics.Telemetry/UsedExporter.cs
+++ b/src/Motor.Extensions.Diagnostics.Telemetry/UsedExporter.cs
@@ -1,0 +1,7 @@
+namespace Motor.Extensions.Diagnostics.Telemetry;
+
+internal enum UsedExporter
+{
+    Otlp,
+    Jaeger,
+}

--- a/src/Motor.Extensions.Diagnostics.Tracing/TracingHostBuilderExtensions.cs
+++ b/src/Motor.Extensions.Diagnostics.Tracing/TracingHostBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using Microsoft.Extensions.Hosting;
 using Motor.Extensions.Diagnostics.Telemetry;
 using Motor.Extensions.Utilities.Abstractions;
 
@@ -17,7 +18,7 @@ public static class TracingHostBuilderExtensions
         TelemetryHostBuilderExtensions.AttributeMotorNetLibraryVersion;
 
     [Obsolete("Replaced by ConfigureOpenTelemetry")]
-    public static IMotorHostBuilder ConfigureJaegerTracing(this IMotorHostBuilder hostBuilder)
+    public static IHostBuilder ConfigureJaegerTracing(this IMotorHostBuilder hostBuilder)
     {
         return hostBuilder.ConfigureOpenTelemetry();
     }

--- a/src/Motor.Extensions.Hosting.Abstractions/IConsumerBuilder.cs
+++ b/src/Motor.Extensions.Hosting.Abstractions/IConsumerBuilder.cs
@@ -1,4 +1,5 @@
 using System;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Motor.Extensions.ContentEncoding.Abstractions;
@@ -9,7 +10,9 @@ namespace Motor.Extensions.Hosting.Abstractions;
 public interface IConsumerBuilder<T> : IServiceCollection
     where T : notnull
 {
-    HostBuilderContext Context { get; }
+    IHostEnvironment HostingEnvironment { get; }
+
+    IConfiguration Configuration { get; }
 
     public void AddConsumer<TConsumer>()
         where TConsumer : IMessageConsumer<T>;

--- a/src/Motor.Extensions.Hosting.Abstractions/IPublisherBuilder.cs
+++ b/src/Motor.Extensions.Hosting.Abstractions/IPublisherBuilder.cs
@@ -10,7 +10,9 @@ namespace Motor.Extensions.Hosting.Abstractions;
 public interface IPublisherBuilder<TOutput> : IServiceCollection
     where TOutput : notnull
 {
-    HostBuilderContext Context { get; }
+    IHostEnvironment HostingEnvironment { get; }
+
+    IConfiguration Configuration { get; }
 
     void ConfigurePublisher(string section);
     void ConfigurePublisher(IConfiguration section);

--- a/src/Motor.Extensions.Hosting.Consumer/ConsumerBuilder.cs
+++ b/src/Motor.Extensions.Hosting.Consumer/ConsumerBuilder.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Motor.Extensions.ContentEncoding.Abstractions;
@@ -17,10 +18,24 @@ public class ConsumerBuilder<T> : IConsumerBuilder<T>
     public ConsumerBuilder(IServiceCollection serviceCollection, HostBuilderContext context)
     {
         _serviceCollection = serviceCollection;
-        Context = context;
+        HostingEnvironment = context.HostingEnvironment;
+        Configuration = context.Configuration;
     }
 
-    public HostBuilderContext Context { get; }
+    public ConsumerBuilder(
+        IServiceCollection serviceCollection,
+        IHostEnvironment hostingEnvironment,
+        IConfiguration configuration
+    )
+    {
+        _serviceCollection = serviceCollection;
+        HostingEnvironment = hostingEnvironment;
+        Configuration = configuration;
+    }
+
+    public IHostEnvironment HostingEnvironment { get; }
+
+    public IConfiguration Configuration { get; }
 
     public void AddConsumer<TConsumer>()
         where TConsumer : IMessageConsumer<T>

--- a/src/Motor.Extensions.Hosting.Consumer/TypedConsumerServiceExtensions.cs
+++ b/src/Motor.Extensions.Hosting.Consumer/TypedConsumerServiceExtensions.cs
@@ -2,26 +2,41 @@ using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Motor.Extensions.Hosting.Abstractions;
-using Motor.Extensions.Utilities.Abstractions;
 
 namespace Motor.Extensions.Hosting.Consumer;
 
 public static class TypedConsumerServiceExtensions
 {
-    public static IMotorHostBuilder ConfigureConsumer<TInput>(
-        this IMotorHostBuilder hostBuilder,
-        Action<HostBuilderContext, IConsumerBuilder<TInput>> action
-    )
-        where TInput : class
+    extension(IHostApplicationBuilder hostBuilder)
     {
-        hostBuilder.ConfigureServices(
-            (context, collection) =>
-            {
-                var consumerBuilder = new ConsumerBuilder<TInput>(collection, context);
-                collection.AddHostedService<TypedConsumerService<TInput>>();
-                action.Invoke(context, consumerBuilder);
-            }
-        );
-        return hostBuilder;
+        public IConsumerBuilder<TInput> AddConsumer<TInput>()
+            where TInput : class
+        {
+            var consumerBuilder = new ConsumerBuilder<TInput>(
+                hostBuilder.Services,
+                hostBuilder.Environment,
+                hostBuilder.Configuration
+            );
+            hostBuilder.Services.AddHostedService<TypedConsumerService<TInput>>();
+
+            return consumerBuilder;
+        }
+    }
+
+    extension(IHostBuilder hostBuilder)
+    {
+        public IHostBuilder ConfigureConsumer<TInput>(Action<HostBuilderContext, IConsumerBuilder<TInput>> action)
+            where TInput : class
+        {
+            hostBuilder.ConfigureServices(
+                (context, collection) =>
+                {
+                    var consumerBuilder = new ConsumerBuilder<TInput>(collection, context);
+                    collection.AddHostedService<TypedConsumerService<TInput>>();
+                    action.Invoke(context, consumerBuilder);
+                }
+            );
+            return hostBuilder;
+        }
     }
 }

--- a/src/Motor.Extensions.Hosting.Kafka/KafkaHostBuilderExtensions.cs
+++ b/src/Motor.Extensions.Hosting.Kafka/KafkaHostBuilderExtensions.cs
@@ -9,31 +9,35 @@ namespace Motor.Extensions.Hosting.Kafka;
 
 public static class KafkaHostBuilderExtensions
 {
-    public static void AddKafkaWithConfig<T>(this IConsumerBuilder<T> builder, IConfiguration config)
+    extension<T>(IConsumerBuilder<T> builder)
         where T : notnull
     {
-        builder.AddTransient<CloudEventFormatter, JsonEventFormatter>();
-        builder.Configure<KafkaConsumerOptions<T>>(config);
-        builder.AddConsumer<KafkaMessageConsumer<T>>();
+        public IConsumerBuilder<T> AddKafkaWithConfig(IConfiguration config)
+        {
+            builder.AddTransient<CloudEventFormatter, JsonEventFormatter>();
+            builder.Configure<KafkaConsumerOptions<T>>(config);
+            builder.AddConsumer<KafkaMessageConsumer<T>>();
+
+            return builder;
+        }
+
+        public IConsumerBuilder<T> AddKafka(string configSection = "KafkaConsumer") =>
+            builder.AddKafkaWithConfig(builder.Configuration.GetSection(configSection));
     }
 
-    public static void AddKafka<T>(this IConsumerBuilder<T> builder, string configSection = "KafkaConsumer")
+    extension<T>(IPublisherBuilder<T> builder)
         where T : notnull
     {
-        builder.AddKafkaWithConfig(builder.Context.Configuration.GetSection(configSection));
-    }
+        public IPublisherBuilder<T> AddKafkaWithConfig(IConfiguration config)
+        {
+            builder.AddTransient<CloudEventFormatter, JsonEventFormatter>();
+            builder.AddPublisher<KafkaMessagePublisher<T>>();
+            builder.Configure<KafkaPublisherOptions<T>>(config);
 
-    public static void AddKafkaWithConfig<T>(this IPublisherBuilder<T> builder, IConfiguration config)
-        where T : notnull
-    {
-        builder.AddTransient<CloudEventFormatter, JsonEventFormatter>();
-        builder.AddPublisher<KafkaMessagePublisher<T>>();
-        builder.Configure<KafkaPublisherOptions<T>>(config);
-    }
+            return builder;
+        }
 
-    public static void AddKafka<T>(this IPublisherBuilder<T> builder, string configSection = "KafkaPublisher")
-        where T : notnull
-    {
-        builder.AddKafkaWithConfig(builder.Context.Configuration.GetSection(configSection));
+        public IPublisherBuilder<T> AddKafka(string configSection = "KafkaPublisher") =>
+            builder.AddKafkaWithConfig(builder.Configuration.GetSection(configSection));
     }
 }

--- a/src/Motor.Extensions.Hosting.NATS/NATSHostBuilderExtensions.cs
+++ b/src/Motor.Extensions.Hosting.NATS/NATSHostBuilderExtensions.cs
@@ -7,43 +7,35 @@ namespace Motor.Extensions.Hosting.NATS;
 
 public static class NATSHostBuilderExtensions
 {
-    public static void AddNATSWithConfig<TInput>(
-        this IConsumerBuilder<TInput> builder,
-        IConfiguration clientConfiguration
-    )
+    extension<TInput>(IConsumerBuilder<TInput> builder)
         where TInput : notnull
     {
-        builder.Configure<NATSConsumerOptions>(clientConfiguration);
-        builder.AddConsumer<NATSMessageConsumer<TInput>>();
-        builder.AddTransient<INATSClientFactory, NATSClientFactory>();
+        public IConsumerBuilder<TInput> AddNATSWithConfig(IConfiguration clientConfiguration)
+        {
+            builder.Configure<NATSConsumerOptions>(clientConfiguration);
+            builder.AddConsumer<NATSMessageConsumer<TInput>>();
+            builder.AddTransient<INATSClientFactory, NATSClientFactory>();
+
+            return builder;
+        }
+
+        public IConsumerBuilder<TInput> AddNATS(string clientConfigSection = "NATSConsumer") =>
+            builder.AddNATSWithConfig(builder.Configuration.GetSection(clientConfigSection));
     }
 
-    public static void AddNATS<TInput>(
-        this IConsumerBuilder<TInput> builder,
-        string clientConfigSection = "NATSConsumer"
-    )
-        where TInput : notnull
-    {
-        builder.AddNATSWithConfig(builder.Context.Configuration.GetSection(clientConfigSection));
-    }
-
-    public static void AddNATSWithConfig<TOutput>(
-        this IPublisherBuilder<TOutput> builder,
-        IConfiguration clientConfiguration
-    )
+    extension<TOutput>(IPublisherBuilder<TOutput> builder)
         where TOutput : notnull
     {
-        builder.Configure<NATSBaseOptions>(clientConfiguration);
-        builder.AddPublisher<NATSMessagePublisher<TOutput>>();
-        builder.AddTransient<INATSClientFactory, NATSClientFactory>();
-    }
+        public IPublisherBuilder<TOutput> AddNATSWithConfig(IConfiguration clientConfiguration)
+        {
+            builder.Configure<NATSBaseOptions>(clientConfiguration);
+            builder.AddPublisher<NATSMessagePublisher<TOutput>>();
+            builder.AddTransient<INATSClientFactory, NATSClientFactory>();
 
-    public static void AddNATS<TOutput>(
-        this IPublisherBuilder<TOutput> builder,
-        string clientConfigSection = "NATSPublisher"
-    )
-        where TOutput : notnull
-    {
-        builder.AddNATSWithConfig(builder.Context.Configuration.GetSection(clientConfigSection));
+            return builder;
+        }
+
+        public IPublisherBuilder<TOutput> AddNATS(string clientConfigSection = "NATSPublisher") =>
+            builder.AddNATSWithConfig(builder.Configuration.GetSection(clientConfigSection));
     }
 }

--- a/src/Motor.Extensions.Hosting.PgMq/PgMqHostBuilderExtensions.cs
+++ b/src/Motor.Extensions.Hosting.PgMq/PgMqHostBuilderExtensions.cs
@@ -16,51 +16,59 @@ namespace Motor.Extensions.Hosting.PgMq;
 
 public static class PgMqHostBuilderExtensions
 {
-    public static void AddPgMqWithConfig<T>(this IConsumerBuilder<T> builder, IConfiguration config)
+    extension<T>(IConsumerBuilder<T> builder)
         where T : notnull
     {
-        var options =
-            config.Get<PgMqConsumerOptions>()
-            ?? throw new InvalidOperationException("PgMqConsumerOptions configuration section is missing or invalid");
-        config.Bind(options);
+        public IConsumerBuilder<T> AddPgMqWithConfig(IConfiguration config)
+        {
+            var options =
+                config.Get<PgMqConsumerOptions>()
+                ?? throw new InvalidOperationException(
+                    "PgMqConsumerOptions configuration section is missing or invalid"
+                );
+            config.Bind(options);
 
-        builder.AddConsumer(sp => new PgMqMessageConsumer<T>(
-            options,
-            sp.GetRequiredService<ILogger<PgMqMessageConsumer<T>>>(),
-            sp.GetRequiredService<IHostApplicationLifetime>(),
-            sp.GetRequiredService<IApplicationNameService>(),
-            new NpgmqClient(options.ToConnectionString())
-        ));
+            builder.AddConsumer(sp => new PgMqMessageConsumer<T>(
+                options,
+                sp.GetRequiredService<ILogger<PgMqMessageConsumer<T>>>(),
+                sp.GetRequiredService<IHostApplicationLifetime>(),
+                sp.GetRequiredService<IApplicationNameService>(),
+                new NpgmqClient(options.ToConnectionString())
+            ));
+
+            return builder;
+        }
+
+        public IConsumerBuilder<T> AddPgMq(string configSection = "PgMqConsumer") =>
+            builder.AddPgMqWithConfig(builder.Configuration.GetSection(configSection));
     }
 
-    public static void AddPgMq<T>(this IConsumerBuilder<T> builder, string configSection = "PgMqConsumer")
+    extension<T>(IPublisherBuilder<T> builder)
         where T : notnull
     {
-        builder.AddPgMqWithConfig(builder.Context.Configuration.GetSection(configSection));
-    }
+        public IPublisherBuilder<T> AddPgMqWithConfig(IConfiguration config)
+        {
+            builder.AddTransient<CloudEventFormatter, JsonEventFormatter>();
 
-    public static void AddPgMqWithConfig<T>(this IPublisherBuilder<T> builder, IConfiguration config)
-        where T : notnull
-    {
-        builder.AddTransient<CloudEventFormatter, JsonEventFormatter>();
+            var options =
+                config.Get<PgMqPublisherOptions>()
+                ?? throw new InvalidOperationException(
+                    "PgMqPublisherOptions configuration section is missing or invalid"
+                );
+            config.Bind(options);
 
-        var options =
-            config.Get<PgMqPublisherOptions>()
-            ?? throw new InvalidOperationException("PgMqPublisherOptions configuration section is missing or invalid");
-        config.Bind(options);
+            builder.Configure<PgMqPublisherOptions>(config);
+            builder.AddPublisher(sp => new PgMqMessageProducer<T>(
+                MSOptions.Create(options),
+                sp.GetRequiredService<ILogger<PgMqMessageProducer<T>>>(),
+                sp.GetRequiredService<IOptions<PublisherOptions>>(),
+                new NpgmqClient(options.ToConnectionString())
+            ));
 
-        builder.Configure<PgMqPublisherOptions>(config);
-        builder.AddPublisher(sp => new PgMqMessageProducer<T>(
-            MSOptions.Create(options),
-            sp.GetRequiredService<ILogger<PgMqMessageProducer<T>>>(),
-            sp.GetRequiredService<IOptions<PublisherOptions>>(),
-            new NpgmqClient(options.ToConnectionString())
-        ));
-    }
+            return builder;
+        }
 
-    public static void AddPgMq<T>(this IPublisherBuilder<T> builder, string configSection = "PgMqPublisher")
-        where T : notnull
-    {
-        builder.AddPgMqWithConfig(builder.Context.Configuration.GetSection(configSection));
+        public IPublisherBuilder<T> AddPgMq(string configSection = "PgMqPublisher") =>
+            builder.AddPgMqWithConfig(builder.Configuration.GetSection(configSection));
     }
 }

--- a/src/Motor.Extensions.Hosting.Publisher/PublisherBuilder.cs
+++ b/src/Motor.Extensions.Hosting.Publisher/PublisherBuilder.cs
@@ -15,21 +15,36 @@ public class PublisherBuilder<TOutput> : IPublisherBuilder<TOutput>
     where TOutput : class
 {
     private readonly IServiceCollection _serviceCollection;
-    private IConfiguration? _configSection;
     private const string PublisherSection = "Publisher";
 
     public PublisherBuilder(IServiceCollection serviceCollection, HostBuilderContext context)
     {
         _serviceCollection = serviceCollection;
-        Context = context;
+        HostingEnvironment = context.HostingEnvironment;
+        Configuration = context.Configuration;
+        serviceCollection.Configure<PublisherOptions>(context.Configuration.GetSection(PublisherSection));
     }
 
-    public Type? PublisherImplType { get; private set; }
-    public HostBuilderContext Context { get; }
+    public PublisherBuilder(
+        IServiceCollection serviceCollection,
+        IHostEnvironment hostingEnvironment,
+        IConfiguration configuration
+    )
+    {
+        _serviceCollection = serviceCollection;
+        HostingEnvironment = hostingEnvironment;
+        Configuration = configuration;
+        serviceCollection.Configure<PublisherOptions>(configuration.GetSection(PublisherSection));
+    }
 
-    public void ConfigurePublisher(string section) => _configSection = Context.Configuration.GetSection(section);
+    public IHostEnvironment HostingEnvironment { get; }
 
-    public void ConfigurePublisher(IConfiguration section) => _configSection = section;
+    public IConfiguration Configuration { get; }
+
+    public void ConfigurePublisher(string section) =>
+        _serviceCollection.Configure<PublisherOptions>(Configuration.GetSection(section));
+
+    public void ConfigurePublisher(IConfiguration section) => _serviceCollection.Configure<PublisherOptions>(section);
 
     public void AddPublisher<TPublisher>()
         where TPublisher : IRawMessagePublisher<TOutput>
@@ -37,16 +52,16 @@ public class PublisherBuilder<TOutput> : IPublisherBuilder<TOutput>
         _serviceCollection.AddTransient(typeof(IRawMessagePublisher<TOutput>), typeof(TPublisher));
         _serviceCollection.AddTransient(typeof(TPublisher));
         _serviceCollection.AddTransient<IMessageEncoder, NoOpMessageEncoder>();
-        PublisherImplType = typeof(TypedMessagePublisher<TOutput, TPublisher>);
+        _serviceCollection.AddSingleton<ITypedMessagePublisher<TOutput>, TypedMessagePublisher<TOutput, TPublisher>>();
     }
 
     public void AddPublisher<TPublisher>(Func<IServiceProvider, TPublisher> implementationFactory)
         where TPublisher : class, IRawMessagePublisher<TOutput>
     {
-        _serviceCollection.AddTransient<IRawMessagePublisher<TOutput>>(sp => implementationFactory(sp));
+        _serviceCollection.AddTransient<IRawMessagePublisher<TOutput>>(implementationFactory);
         _serviceCollection.AddTransient(implementationFactory);
         _serviceCollection.AddTransient<IMessageEncoder, NoOpMessageEncoder>();
-        PublisherImplType = typeof(TypedMessagePublisher<TOutput, TPublisher>);
+        _serviceCollection.AddSingleton<ITypedMessagePublisher<TOutput>, TypedMessagePublisher<TOutput, TPublisher>>();
     }
 
     public void AddSerializer<TSerializer>()
@@ -88,15 +103,12 @@ public class PublisherBuilder<TOutput> : IPublisherBuilder<TOutput>
 
     public void Build(Action<HostBuilderContext, IPublisherBuilder<TOutput>> action)
     {
-        action(Context, this);
-        if (PublisherImplType is null)
+        var context = new HostBuilderContext(new Dictionary<object, object>())
         {
-            throw new ArgumentNullException(nameof(PublisherImplType));
-        }
-        _serviceCollection.AddSingleton(typeof(ITypedMessagePublisher<TOutput>), PublisherImplType);
-        _serviceCollection.AddHostedService<TypedPublisherService<TOutput>>();
+            Configuration = Configuration,
+            HostingEnvironment = HostingEnvironment,
+        };
 
-        _configSection ??= Context.Configuration.GetSection(PublisherSection);
-        _serviceCollection.Configure<PublisherOptions>(_configSection);
+        action(context, this);
     }
 }

--- a/src/Motor.Extensions.Hosting.Publisher/PublisherFactoryExtensions.cs
+++ b/src/Motor.Extensions.Hosting.Publisher/PublisherFactoryExtensions.cs
@@ -1,25 +1,40 @@
 using System;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Motor.Extensions.Hosting.Abstractions;
-using Motor.Extensions.Utilities.Abstractions;
 
 namespace Motor.Extensions.Hosting.Publisher;
 
 public static class TypedMessagePublisherExtensions
 {
-    public static IMotorHostBuilder ConfigurePublisher<TOutput>(
-        this IMotorHostBuilder hostBuilder,
-        Action<HostBuilderContext, IPublisherBuilder<TOutput>> action
-    )
+    extension<TOutput>(IHostApplicationBuilder hostBuilder)
         where TOutput : class
     {
-        hostBuilder.ConfigureServices(
-            (context, collection) =>
-            {
-                var consumerBuilder = new PublisherBuilder<TOutput>(collection, context);
-                consumerBuilder.Build(action);
-            }
-        );
-        return hostBuilder;
+        public IPublisherBuilder<TOutput> AddPublisher()
+        {
+            hostBuilder.Services.AddHostedService<TypedPublisherService<TOutput>>();
+            return new PublisherBuilder<TOutput>(
+                hostBuilder.Services,
+                hostBuilder.Environment,
+                hostBuilder.Configuration
+            );
+        }
+    }
+
+    extension<TOutput>(IHostBuilder builder)
+        where TOutput : class
+    {
+        public IHostBuilder ConfigurePublisher(Action<HostBuilderContext, IPublisherBuilder<TOutput>> action)
+        {
+            builder.ConfigureServices(
+                (context, services) =>
+                {
+                    services.AddHostedService<TypedPublisherService<TOutput>>();
+                    var consumerBuilder = new PublisherBuilder<TOutput>(services, context);
+                    consumerBuilder.Build(action);
+                }
+            );
+            return builder;
+        }
     }
 }

--- a/src/Motor.Extensions.Hosting.RabbitMQ/BasicDeliverEventArgsExtensions.cs
+++ b/src/Motor.Extensions.Hosting.RabbitMQ/BasicDeliverEventArgsExtensions.cs
@@ -6,20 +6,22 @@ namespace Motor.Extensions.Hosting.RabbitMQ;
 
 public static class BasicDeliverEventArgsExtensions
 {
-    public static MotorCloudEvent<byte[]> ExtractCloudEvent(
-        this BasicDeliverEventArgs self,
-        IApplicationNameService applicationNameService,
-        ReadOnlyMemory<byte> body,
-        bool extractBindingKey
-    )
+    extension(BasicDeliverEventArgs self)
     {
-        var cloudEvent = self.BasicProperties.ExtractCloudEvent(applicationNameService, body);
-
-        if (extractBindingKey)
+        public MotorCloudEvent<byte[]> ExtractCloudEvent(
+            IApplicationNameService applicationNameService,
+            ReadOnlyMemory<byte> body,
+            bool extractBindingKey
+        )
         {
-            cloudEvent.SetRabbitMQBinding(self.Exchange, self.RoutingKey);
-        }
+            var cloudEvent = self.BasicProperties.ExtractCloudEvent(applicationNameService, body);
 
-        return cloudEvent;
+            if (extractBindingKey)
+            {
+                cloudEvent.SetRabbitMQBinding(self.Exchange, self.RoutingKey);
+            }
+
+            return cloudEvent;
+        }
     }
 }

--- a/src/Motor.Extensions.Hosting.RabbitMQ/BasicPropertiesExtensions.cs
+++ b/src/Motor.Extensions.Hosting.RabbitMQ/BasicPropertiesExtensions.cs
@@ -16,127 +16,131 @@ public static class BasicPropertiesExtensions
 
     // ReSharper disable once InconsistentNaming
     private static readonly Version Version_0_7_0 = new("0.7.0.0");
-    private static readonly List<CloudEventAttribute> IgnoredAttributes = new();
 
-    static BasicPropertiesExtensions()
-    {
-        IgnoredAttributes.AddRange(RabbitMQBindingExtension.AllAttributes);
-        IgnoredAttributes.AddRange(RabbitMQPriorityExtension.AllAttributes);
-        IgnoredAttributes.AddRange(EncodingExtension.AllAttributes);
-        IgnoredAttributes.Add(MotorCloudEventInfo.SpecVersion.DataContentTypeAttribute);
-    }
+    private static readonly IReadOnlyList<CloudEventAttribute> IgnoredAttributes =
+    [
+        .. RabbitMQBindingExtension.AllAttributes,
+        .. RabbitMQPriorityExtension.AllAttributes,
+        .. EncodingExtension.AllAttributes,
+        MotorCloudEventInfo.SpecVersion.DataContentTypeAttribute,
+    ];
 
-    public static void SetPriority<T>(
-        this IBasicProperties self,
-        MotorCloudEvent<byte[]> cloudEvent,
-        RabbitMQPublisherOptions<T> options
-    )
+    extension(IBasicProperties self)
     {
-        var messagePriority = cloudEvent.GetRabbitMQPriority() ?? options.DefaultPriority;
-        if (messagePriority.HasValue)
+        public void SetPriority<T>(MotorCloudEvent<byte[]> cloudEvent, RabbitMQPublisherOptions<T> options)
         {
-            self.Priority = messagePriority.Value;
+            var messagePriority = cloudEvent.GetRabbitMQPriority() ?? options.DefaultPriority;
+            if (messagePriority.HasValue)
+            {
+                self.Priority = messagePriority.Value;
+            }
+        }
+
+        public void WriteCloudEventIntoHeader(MotorCloudEvent<byte[]> cloudEvent)
+        {
+            self.ContentEncoding = cloudEvent.GetEncoding();
+            self.ContentType = cloudEvent.ContentType;
+
+            var headers = new Dictionary<string, object?>();
+
+            var attributesToConsider = cloudEvent
+                .GetPopulatedAttributes()
+                .Where(t => !IgnoredAttributes.Contains(t.Key));
+
+            foreach (var (key, value) in attributesToConsider)
+            {
+                headers.Add($"{CloudEventPrefix}{key.Name}", Encoding.UTF8.GetBytes(key.Format(value)));
+            }
+
+            self.Headers = headers;
         }
     }
 
-    public static void WriteCloudEventIntoHeader(this IBasicProperties self, MotorCloudEvent<byte[]> cloudEvent)
+    extension(IReadOnlyBasicProperties self)
     {
-        self.ContentEncoding = cloudEvent.GetEncoding();
-        self.ContentType = cloudEvent.ContentType;
-
-        var headers = new Dictionary<string, object?>();
-
-        var attributesToConsider = cloudEvent.GetPopulatedAttributes().Where(t => !IgnoredAttributes.Contains(t.Key));
-
-        foreach (var (key, value) in attributesToConsider)
+        public MotorCloudEvent<byte[]> ExtractCloudEvent(
+            IApplicationNameService applicationNameService,
+            ReadOnlyMemory<byte> body
+        )
         {
-            headers.Add($"{CloudEventPrefix}{key.Name}", Encoding.UTF8.GetBytes(key.Format(value)));
-        }
+            var attributes = new Dictionary<string, object?>();
+            IDictionary<string, object?> headers = new Dictionary<string, object?>();
+            if (self.IsHeadersPresent() && self.Headers is not null)
+            {
+                headers = self.Headers;
+            }
 
-        self.Headers = headers;
-    }
+            var cloudEventHeaders = headers
+                .Where(t => t.Key.StartsWith(CloudEventPrefix))
+                .Select(t => (Key: t.Key[CloudEventPrefix.Length..], t.Value))
+                .Where(t =>
+                    !t.Key.Equals(
+                        CloudEventsSpecVersion.SpecVersionAttribute.Name,
+                        StringComparison.InvariantCultureIgnoreCase
+                    )
+                );
 
-    public static MotorCloudEvent<byte[]> ExtractCloudEvent(
-        this IReadOnlyBasicProperties self,
-        IApplicationNameService applicationNameService,
-        ReadOnlyMemory<byte> body
-    )
-    {
-        var attributes = new Dictionary<string, object?>();
-        IDictionary<string, object?> headers = new Dictionary<string, object?>();
-        if (self.IsHeadersPresent() && self.Headers is not null)
-        {
-            headers = self.Headers;
-        }
+            foreach (var (key, value) in cloudEventHeaders)
+            {
+                attributes.Add(key, value);
+            }
 
-        var cloudEventHeaders = headers
-            .Where(t => t.Key.StartsWith(CloudEventPrefix))
-            .Select(t => (Key: t.Key[CloudEventPrefix.Length..], t.Value))
-            .Where(t =>
-                !t.Key.Equals(
-                    CloudEventsSpecVersion.SpecVersionAttribute.Name,
-                    StringComparison.InvariantCultureIgnoreCase
-                )
+            var cloudEvent = new MotorCloudEvent<byte[]>(
+                applicationNameService,
+                body.ToArray(),
+                null,
+                new Uri("rabbitmq://notset"),
+                null,
+                null,
+                self.ContentType
             );
 
-        foreach (var (key, value) in cloudEventHeaders)
-        {
-            attributes.Add(key, value);
-        }
+            if (self.IsPriorityPresent())
+            {
+                cloudEvent.SetRabbitMQPriority(self.Priority);
+            }
 
-        var cloudEvent = new MotorCloudEvent<byte[]>(
-            applicationNameService,
-            body.ToArray(),
-            null,
-            new Uri("rabbitmq://notset"),
-            null,
-            null,
-            self.ContentType
-        );
+            cloudEvent.SetEncoding(self.ContentEncoding);
 
-        if (self.IsPriorityPresent())
-        {
-            cloudEvent.SetRabbitMQPriority(self.Priority);
-        }
+            if (attributes.Count == 0)
+            {
+                return cloudEvent;
+            }
 
-        cloudEvent.SetEncoding(self.ContentEncoding);
+            var hasVersion = attributes.TryGetValue(
+                MotorVersionExtension.MotorVersionAttribute.Name,
+                out var versionObject
+            );
+            Version? version = null;
+            if (hasVersion && versionObject is byte[] versionBytes)
+            {
+                var versionString = Encoding.UTF8.GetString(versionBytes);
+                // If the version is enclosed in double quotes, that means it has passed an old Motor.NET version as an
+                // unknown header. Therefore, the version number should not be trusted and instead, the version is set
+                // to null.
+                version =
+                    versionString.StartsWith('"') || versionString.EndsWith('"')
+                        ? null
+                        : new Version(Encoding.UTF8.GetString(versionBytes));
+            }
 
-        if (attributes.Count == 0)
-        {
+            foreach (var (key, value) in attributes)
+            {
+                if (value is not byte[] byteValue)
+                {
+                    continue;
+                }
+
+                var decoded = Encoding.UTF8.GetString(byteValue);
+                if ((version is null || version < Version_0_7_0) && decoded.StartsWith("\"") && decoded.EndsWith("\""))
+                {
+                    decoded = decoded.Substring(1, decoded.Length - 2);
+                }
+
+                cloudEvent.SetAttributeFromString(key.ToLowerInvariant(), decoded);
+            }
+
             return cloudEvent;
         }
-
-        var hasVersion = attributes.TryGetValue(
-            MotorVersionExtension.MotorVersionAttribute.Name,
-            out var versionObject
-        );
-        Version? version = null;
-        if (hasVersion && versionObject is byte[] versionBytes)
-        {
-            var versionString = Encoding.UTF8.GetString(versionBytes);
-            // If the version is enclosed in double quotes, that means it has passed an old Motor.NET version as an
-            // unknown header. Therefore, the version number should not be trusted and instead, the version is set
-            // to null.
-            version =
-                versionString.StartsWith("\"") || versionString.EndsWith("\"")
-                    ? null
-                    : new Version(Encoding.UTF8.GetString(versionBytes));
-        }
-
-        foreach (var (key, value) in attributes)
-        {
-            if (value is not byte[] byteValue)
-            {
-                continue;
-            }
-            var decoded = Encoding.UTF8.GetString(byteValue);
-            if ((version is null || version < Version_0_7_0) && decoded.StartsWith("\"") && decoded.EndsWith("\""))
-            {
-                decoded = decoded.Substring(1, decoded.Length - 2);
-            }
-            cloudEvent.SetAttributeFromString(key.ToLowerInvariant(), decoded);
-        }
-
-        return cloudEvent;
     }
 }

--- a/src/Motor.Extensions.Hosting.RabbitMQ/RabbitMQBindingExtension.cs
+++ b/src/Motor.Extensions.Hosting.RabbitMQ/RabbitMQBindingExtension.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using CloudNative.CloudEvents;
 using Motor.Extensions.Hosting.CloudEvents;
 using CloudEventValidation = CloudNative.CloudEvents.Core.Validation;
@@ -14,31 +13,24 @@ public static class RabbitMQBindingExtension
     public static CloudEventAttribute RabbitMQRoutingKeyAttribute { get; } =
         CloudEventAttribute.CreateExtension("bindingroutingkey", CloudEventAttributeType.String);
 
-    public static IEnumerable<CloudEventAttribute> AllAttributes { get; } =
-        new[] { RabbitMQExchangeAttribute, RabbitMQRoutingKeyAttribute }.ToList().AsReadOnly();
+    public static IReadOnlyList<CloudEventAttribute> AllAttributes { get; } =
+    [RabbitMQExchangeAttribute, RabbitMQRoutingKeyAttribute];
 
-    public static MotorCloudEvent<TData> SetRabbitMQBinding<TData>(
-        this MotorCloudEvent<TData> cloudEvent,
-        string? exchange,
-        string? routingKey
-    )
+    extension<TData>(MotorCloudEvent<TData> cloudEvent)
         where TData : class
     {
-        CloudEventValidation.CheckNotNull(cloudEvent, nameof(cloudEvent));
-        cloudEvent[RabbitMQExchangeAttribute] = exchange;
-        cloudEvent[RabbitMQRoutingKeyAttribute] = routingKey;
-        return cloudEvent;
-    }
+        public MotorCloudEvent<TData> SetRabbitMQBinding(string? exchange, string? routingKey)
+        {
+            CloudEventValidation.CheckNotNull(cloudEvent, nameof(cloudEvent));
+            cloudEvent[RabbitMQExchangeAttribute] = exchange;
+            cloudEvent[RabbitMQRoutingKeyAttribute] = routingKey;
+            return cloudEvent;
+        }
 
-    public static string? GetRabbitMQExchange<TData>(this MotorCloudEvent<TData> cloudEvent)
-        where TData : class
-    {
-        return CloudEventValidation.CheckNotNull(cloudEvent, nameof(cloudEvent))[RabbitMQExchangeAttribute] as string;
-    }
+        public string? GetRabbitMQExchange() =>
+            CloudEventValidation.CheckNotNull(cloudEvent, nameof(cloudEvent))[RabbitMQExchangeAttribute] as string;
 
-    public static string? GetRabbitMQRoutingKey<TData>(this MotorCloudEvent<TData> cloudEvent)
-        where TData : class
-    {
-        return CloudEventValidation.CheckNotNull(cloudEvent, nameof(cloudEvent))[RabbitMQRoutingKeyAttribute] as string;
+        public string? GetRabbitMQRoutingKey() =>
+            CloudEventValidation.CheckNotNull(cloudEvent, nameof(cloudEvent))[RabbitMQRoutingKeyAttribute] as string;
     }
 }

--- a/src/Motor.Extensions.Hosting.RabbitMQ/RabbitMQMessageHostBuilderExtensions.cs
+++ b/src/Motor.Extensions.Hosting.RabbitMQ/RabbitMQMessageHostBuilderExtensions.cs
@@ -15,52 +15,56 @@ namespace Motor.Extensions.Hosting.RabbitMQ;
 
 public static class RabbitMQMessageHostBuilderExtensions
 {
-    public static void AddRabbitMQWithConfig<T>(this IConsumerBuilder<T> builder, IConfiguration config)
+    extension<T>(IConsumerBuilder<T> builder)
         where T : notnull
     {
-        builder.AddTransient<CloudEventFormatter, JsonEventFormatter>();
-        var consumerOptions = new RabbitMQConsumerOptions<T>();
-        config.Bind(consumerOptions);
-        var connectionFactory = RabbitMQConnectionFactory<T>.From(consumerOptions);
-        builder.AddConsumer(sp => new RabbitMQMessageConsumer<T>(
-            sp.GetRequiredService<ILogger<RabbitMQMessageConsumer<T>>>(),
-            connectionFactory,
-            MSOptions.Create(consumerOptions),
-            sp.GetRequiredService<IHostApplicationLifetime>(),
-            sp.GetRequiredService<IApplicationNameService>()
-        ));
-        builder.AddSingleton<IQueueMonitor>(sp => new RabbitMQQueueMonitor<T>(
-            sp.GetRequiredService<ILogger<RabbitMQQueueMonitor<T>>>(),
-            MSOptions.Create(consumerOptions),
-            connectionFactory
-        ));
+        public IConsumerBuilder<T> AddRabbitMQWithConfig(IConfiguration config)
+        {
+            builder.AddTransient<CloudEventFormatter, JsonEventFormatter>();
+            var consumerOptions = new RabbitMQConsumerOptions<T>();
+            config.Bind(consumerOptions);
+            var connectionFactory = RabbitMQConnectionFactory<T>.From(consumerOptions);
+            builder.AddConsumer(sp => new RabbitMQMessageConsumer<T>(
+                sp.GetRequiredService<ILogger<RabbitMQMessageConsumer<T>>>(),
+                connectionFactory,
+                MSOptions.Create(consumerOptions),
+                sp.GetRequiredService<IHostApplicationLifetime>(),
+                sp.GetRequiredService<IApplicationNameService>()
+            ));
+            builder.AddSingleton<IQueueMonitor>(sp => new RabbitMQQueueMonitor<T>(
+                sp.GetRequiredService<ILogger<RabbitMQQueueMonitor<T>>>(),
+                MSOptions.Create(consumerOptions),
+                connectionFactory
+            ));
+
+            return builder;
+        }
+
+        public IConsumerBuilder<T> AddRabbitMQ(string configSection = "RabbitMQConsumer") =>
+            builder.AddRabbitMQWithConfig(builder.Configuration.GetSection(configSection));
     }
 
-    public static void AddRabbitMQ<T>(this IConsumerBuilder<T> builder, string configSection = "RabbitMQConsumer")
+    extension<T>(IPublisherBuilder<T> builder)
         where T : notnull
     {
-        builder.AddRabbitMQWithConfig(builder.Context.Configuration.GetSection(configSection));
-    }
+        public IPublisherBuilder<T> AddRabbitMQWithConfig(IConfiguration config)
+        {
+            builder.AddTransient<CloudEventFormatter, JsonEventFormatter>();
+            builder.Configure<RabbitMQPublisherOptions<T>>(config);
 
-    public static void AddRabbitMQWithConfig<T>(this IPublisherBuilder<T> builder, IConfiguration config)
-        where T : notnull
-    {
-        builder.AddTransient<CloudEventFormatter, JsonEventFormatter>();
-        builder.Configure<RabbitMQPublisherOptions<T>>(config);
+            var rabbitMqPublisherOptions = config.Get<RabbitMQPublisherOptions<T>>();
+            var connectionFactory = RabbitMQConnectionFactory<T>.From(rabbitMqPublisherOptions);
+            builder.AddPublisher(sp => new RabbitMQMessagePublisher<T>(
+                connectionFactory,
+                MSOptions.Create(rabbitMqPublisherOptions),
+                sp.GetRequiredService<IOptions<PublisherOptions>>(),
+                sp.GetRequiredService<CloudEventFormatter>()
+            ));
 
-        var rabbitMqPublisherOptions = config.Get<RabbitMQPublisherOptions<T>>();
-        var connectionFactory = RabbitMQConnectionFactory<T>.From(rabbitMqPublisherOptions);
-        builder.AddPublisher(sp => new RabbitMQMessagePublisher<T>(
-            connectionFactory,
-            MSOptions.Create(rabbitMqPublisherOptions),
-            sp.GetRequiredService<IOptions<PublisherOptions>>(),
-            sp.GetRequiredService<CloudEventFormatter>()
-        ));
-    }
+            return builder;
+        }
 
-    public static void AddRabbitMQ<T>(this IPublisherBuilder<T> builder, string configSection = "RabbitMQPublisher")
-        where T : notnull
-    {
-        builder.AddRabbitMQWithConfig(builder.Context.Configuration.GetSection(configSection));
+        public IPublisherBuilder<T> AddRabbitMQ(string configSection = "RabbitMQPublisher") =>
+            builder.AddRabbitMQWithConfig(builder.Configuration.GetSection(configSection));
     }
 }

--- a/src/Motor.Extensions.Hosting.RabbitMQ/RabbitMQPriorityExtension.cs
+++ b/src/Motor.Extensions.Hosting.RabbitMQ/RabbitMQPriorityExtension.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using CloudNative.CloudEvents;
 using Motor.Extensions.Hosting.CloudEvents;
 using CloudEventValidation = CloudNative.CloudEvents.Core.Validation;
@@ -11,25 +10,24 @@ public static class RabbitMQPriorityExtension
     public static CloudEventAttribute RabbitMQPriorityAttribute { get; } =
         CloudEventAttribute.CreateExtension("priority", CloudEventAttributeType.Integer);
 
-    public static IEnumerable<CloudEventAttribute> AllAttributes { get; } =
-        new[] { RabbitMQPriorityAttribute }.ToList().AsReadOnly();
+    public static IReadOnlyList<CloudEventAttribute> AllAttributes { get; } = [RabbitMQPriorityAttribute];
 
-    public static MotorCloudEvent<TData> SetRabbitMQPriority<TData>(this MotorCloudEvent<TData> cloudEvent, byte? value)
+    extension<TData>(MotorCloudEvent<TData> cloudEvent)
         where TData : class
     {
-        CloudEventValidation.CheckNotNull(cloudEvent, nameof(cloudEvent));
-        cloudEvent[RabbitMQPriorityAttribute] = (int?)value;
-        return cloudEvent;
-    }
-
-    public static byte? GetRabbitMQPriority<TData>(this MotorCloudEvent<TData> cloudEvent)
-        where TData : class
-    {
-        return CloudEventValidation.CheckNotNull(cloudEvent, nameof(cloudEvent))[RabbitMQPriorityAttribute] switch
+        public MotorCloudEvent<TData> SetRabbitMQPriority(byte? value)
         {
-            int and (< 0 or > 255) => null,
-            int priority => (byte)priority,
-            _ => null,
-        };
+            CloudEventValidation.CheckNotNull(cloudEvent, nameof(cloudEvent));
+            cloudEvent[RabbitMQPriorityAttribute] = (int?)value;
+            return cloudEvent;
+        }
+
+        public byte? GetRabbitMQPriority() =>
+            CloudEventValidation.CheckNotNull(cloudEvent, nameof(cloudEvent))[RabbitMQPriorityAttribute] switch
+            {
+                int and (< 0 or > 255) => null,
+                int priority => (byte)priority,
+                _ => null,
+            };
     }
 }

--- a/src/Motor.Extensions.Hosting.SQS/SQSHostBuilderExtensions.cs
+++ b/src/Motor.Extensions.Hosting.SQS/SQSHostBuilderExtensions.cs
@@ -7,17 +7,19 @@ namespace Motor.Extensions.Hosting.SQS;
 
 public static class SQSHostBuilderExtensions
 {
-    public static void AddSQSWithConfig<T>(this IConsumerBuilder<T> builder, IConfiguration clientConfiguration)
+    extension<T>(IConsumerBuilder<T> builder)
         where T : notnull
     {
-        builder.Configure<SQSClientOptions>(clientConfiguration);
-        builder.AddConsumer<SQSConsumer<T>>();
-        builder.AddTransient<ISQSClientFactory, SQSClientFactory>();
-    }
+        public IConsumerBuilder<T> AddSQSWithConfig(IConfiguration clientConfiguration)
+        {
+            builder.Configure<SQSClientOptions>(clientConfiguration);
+            builder.AddConsumer<SQSConsumer<T>>();
+            builder.AddTransient<ISQSClientFactory, SQSClientFactory>();
 
-    public static void AddSQS<T>(this IConsumerBuilder<T> builder, string clientConfigSection = "SQSConsumer")
-        where T : notnull
-    {
-        builder.AddSQSWithConfig(builder.Context.Configuration.GetSection(clientConfigSection));
+            return builder;
+        }
+
+        public IConsumerBuilder<T> AddSQS(string clientConfigSection = "SQSConsumer") =>
+            builder.AddSQSWithConfig(builder.Configuration.GetSection(clientConfigSection));
     }
 }

--- a/src/Motor.Extensions.Hosting.Timer/TimerHostBuilderExtensions.cs
+++ b/src/Motor.Extensions.Hosting.Timer/TimerHostBuilderExtensions.cs
@@ -7,6 +7,19 @@ namespace Motor.Extensions.Hosting.Timer;
 
 public static class TimerHostBuilderExtensions
 {
+    extension(IHostApplicationBuilder builder)
+    {
+        public IHostApplicationBuilder ConfigureTimer(string configSection = "Timer")
+        {
+            builder.ConfigureNoOutputService<IJobExecutionContext>();
+            var config = builder.Configuration.GetSection(configSection);
+            builder.Services.Configure<TimerOptions>(config);
+            builder.Services.AddHostedService<Timer>();
+
+            return builder;
+        }
+    }
+
     extension(IHostBuilder builder)
     {
         public IHostBuilder ConfigureTimer(string configSection = "Timer") =>

--- a/src/Motor.Extensions.Hosting.Timer/TimerHostBuilderExtensions.cs
+++ b/src/Motor.Extensions.Hosting.Timer/TimerHostBuilderExtensions.cs
@@ -1,23 +1,24 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Motor.Extensions.Utilities;
-using Motor.Extensions.Utilities.Abstractions;
 using Quartz;
 
 namespace Motor.Extensions.Hosting.Timer;
 
 public static class TimerHostBuilderExtensions
 {
-    public static IMotorHostBuilder ConfigureTimer(this IMotorHostBuilder hostBuilder, string configSection = "Timer")
+    extension(IHostBuilder builder)
     {
-        return hostBuilder
-            .ConfigureNoOutputService<IJobExecutionContext>()
-            .ConfigureServices(
-                (hostContext, services) =>
-                {
-                    var config = hostContext.Configuration.GetSection(configSection);
-                    services.Configure<TimerOptions>(config);
-                    services.AddHostedService<Timer>();
-                }
-            );
+        public IHostBuilder ConfigureTimer(string configSection = "Timer") =>
+            builder
+                .ConfigureNoOutputService<IJobExecutionContext>()
+                .ConfigureServices(
+                    (hostContext, services) =>
+                    {
+                        var config = hostContext.Configuration.GetSection(configSection);
+                        services.Configure<TimerOptions>(config);
+                        services.AddHostedService<Timer>();
+                    }
+                );
     }
 }

--- a/src/Motor.Extensions.Hosting/DefaultApplicationNameService.cs
+++ b/src/Motor.Extensions.Hosting/DefaultApplicationNameService.cs
@@ -25,14 +25,13 @@ public class DefaultApplicationNameService : IApplicationNameService
 
     private string GetProduct()
     {
-        var assemblyProductAttribute = (AssemblyProductAttribute?)
-            Attribute.GetCustomAttribute(_assembly, typeof(AssemblyProductAttribute));
-        if (assemblyProductAttribute?.Product == GetAssemblyName())
+        var assemblyProductAttribute = _assembly.GetCustomAttribute<AssemblyProductAttribute>();
+        if (assemblyProductAttribute?.Product.Equals(GetAssemblyName()) ?? true)
         {
             throw new InvalidProgramException("Product is not set.");
         }
 
-        return assemblyProductAttribute!.Product;
+        return assemblyProductAttribute.Product;
     }
 
     public string GetVersion()

--- a/src/Motor.Extensions.Http/DefaultHostBuilderExtensions.cs
+++ b/src/Motor.Extensions.Http/DefaultHostBuilderExtensions.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -12,62 +11,60 @@ namespace Motor.Extensions.Http;
 
 public static class DefaultHostBuilderExtensions
 {
-    public static IHostBuilder ConfigureDefaultHttpClient(
-        this IHostBuilder hostBuilder,
-        string configSection = "Request"
-    )
+    extension(IHostBuilder builder)
     {
-        return hostBuilder.ConfigureServices(
-            (context, services) =>
-            {
-                services
-                    .AddTransient<PrometheusDelegatingHandler>()
-                    .Configure<HttpOptions>(context.Configuration.GetSection(configSection))
-                    .AddHttpClient(Options.DefaultName);
-            }
-        );
-    }
-
-    public static IHttpClientBuilder AddDefaultHttpClient(this IServiceCollection services, string name)
-    {
-        return services.AddHttpClient(name).AddDefaultBehaviour();
-    }
-
-    public static IHttpClientBuilder AddDefaultHttpClient<TClient, TImplementation>(this IServiceCollection services)
-        where TClient : class
-        where TImplementation : class, TClient
-    {
-        return services.AddHttpClient<TClient, TImplementation>().AddDefaultBehaviour();
-    }
-
-    private static IHttpClientBuilder AddDefaultBehaviour(this IHttpClientBuilder clientBuilder)
-    {
-        return clientBuilder
-            .AddPolicyHandler(
-                (provider, _) =>
+        public IHostBuilder ConfigureDefaultHttpClient(string configSection = "Request") =>
+            builder.ConfigureServices(
+                (context, services) =>
                 {
-                    var config = (IOptions<HttpOptions>?)provider.GetService(typeof(IOptions<HttpOptions>));
-                    var nonTransientStatusCodesToRetry =
-                        config?.Value.NonTransientStatusCodesToRetry ?? Array.Empty<int>();
-                    return HttpPolicyExtensions
-                        .HandleTransientHttpError()
-                        .Or<TimeoutRejectedException>() // thrown by Polly's TimeoutPolicy if the inner call times out
-                        .OrResult(r => nonTransientStatusCodesToRetry.Contains((int)r.StatusCode))
-                        .WaitAndRetryAsync(
-                            config?.Value.NumberOfRetries ?? HttpOptions.DefaultNumberOfRetries,
-                            i => TimeSpan.FromSeconds(Math.Pow(2, i))
+                    services
+                        .AddTransient<PrometheusDelegatingHandler>()
+                        .Configure<HttpOptions>(context.Configuration.GetSection(configSection))
+                        .AddHttpClient(Options.DefaultName);
+                }
+            );
+    }
+
+    extension(IServiceCollection services)
+    {
+        public IHttpClientBuilder AddDefaultHttpClient(string name) =>
+            services.AddHttpClient(name).AddDefaultBehaviour();
+
+        public IHttpClientBuilder AddDefaultHttpClient<TClient, TImplementation>()
+            where TClient : class
+            where TImplementation : class, TClient =>
+            services.AddHttpClient<TClient, TImplementation>().AddDefaultBehaviour();
+    }
+
+    extension(IHttpClientBuilder clientBuilder)
+    {
+        private IHttpClientBuilder AddDefaultBehaviour() =>
+            clientBuilder
+                .AddPolicyHandler(
+                    (provider, _) =>
+                    {
+                        var config = (IOptions<HttpOptions>?)provider.GetService(typeof(IOptions<HttpOptions>));
+                        var nonTransientStatusCodesToRetry =
+                            config?.Value.NonTransientStatusCodesToRetry ?? Array.Empty<int>();
+                        return HttpPolicyExtensions
+                            .HandleTransientHttpError()
+                            .Or<TimeoutRejectedException>() // thrown by Polly's TimeoutPolicy if the inner call times out
+                            .OrResult(r => nonTransientStatusCodesToRetry.Contains((int)r.StatusCode))
+                            .WaitAndRetryAsync(
+                                config?.Value.NumberOfRetries ?? HttpOptions.DefaultNumberOfRetries,
+                                i => TimeSpan.FromSeconds(Math.Pow(2, i))
+                            );
+                    }
+                )
+                .AddPolicyHandler(
+                    (provider, _) =>
+                    {
+                        var config = (IOptions<HttpOptions>?)provider.GetService(typeof(IOptions<HttpOptions>));
+                        return Policy.TimeoutAsync<HttpResponseMessage>(
+                            config?.Value.TimeoutInSeconds ?? HttpOptions.DefaultTimeoutInSeconds
                         );
-                }
-            )
-            .AddPolicyHandler(
-                (provider, _) =>
-                {
-                    var config = (IOptions<HttpOptions>?)provider.GetService(typeof(IOptions<HttpOptions>));
-                    return Policy.TimeoutAsync<HttpResponseMessage>(
-                        config?.Value.TimeoutInSeconds ?? HttpOptions.DefaultTimeoutInSeconds
-                    );
-                }
-            )
-            .AddHttpMessageHandler<PrometheusDelegatingHandler>();
+                    }
+                )
+                .AddHttpMessageHandler<PrometheusDelegatingHandler>();
     }
 }

--- a/src/Motor.Extensions.TestUtilities/MotorWebApplicationFactory.cs
+++ b/src/Motor.Extensions.TestUtilities/MotorWebApplicationFactory.cs
@@ -47,15 +47,13 @@ public class MotorWebApplicationFactory<TStartup> : WebApplicationFactory<TStart
 
     public async Task<bool> IsHealthy()
     {
-        var client = CreateClient();
+        using var client = CreateClient();
         var response = await client.GetAsync("/health");
         return response.IsSuccessStatusCode;
     }
 
     public async Task WaitUntilHealthy()
     {
-        CreateClient();
-
         var retryPolicy = Policy
             .HandleResult<bool>(healthy => !healthy)
             .WaitAndRetryAsync(10, retryAttempt => TimeSpan.FromMilliseconds(Math.Pow(2, retryAttempt)));

--- a/src/Motor.Extensions.Utilities.Abstractions/IMotorHostBuilder.cs
+++ b/src/Motor.Extensions.Utilities.Abstractions/IMotorHostBuilder.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 
 namespace Motor.Extensions.Utilities.Abstractions;
@@ -11,11 +9,4 @@ public interface IMotorHostBuilder : IHostBuilder
     new IMotorHostBuilder ConfigureServices(Action<HostBuilderContext, IServiceCollection> configureDelegate);
     IMotorHostBuilder UseStartup<T>()
         where T : IMotorStartup;
-
-    IMotorHostBuilder AddHealthCheck<T>(
-        string name,
-        HealthStatus? failureStatus = null,
-        IEnumerable<string>? tags = null,
-        TimeSpan? timeout = null
-    );
 }

--- a/src/Motor.Extensions.Utilities/DefaultHostBuilderExtensions.cs
+++ b/src/Motor.Extensions.Utilities/DefaultHostBuilderExtensions.cs
@@ -1,5 +1,3 @@
-using System;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Motor.Extensions.Diagnostics.Metrics;
@@ -7,90 +5,142 @@ using Motor.Extensions.Diagnostics.Telemetry;
 using Motor.Extensions.Hosting;
 using Motor.Extensions.Hosting.Abstractions;
 using Motor.Extensions.Hosting.HealthChecks;
-using Motor.Extensions.Utilities.Abstractions;
 
 namespace Motor.Extensions.Utilities;
 
 public static class DefaultHostBuilderExtensions
 {
-    public static IMotorHostBuilder ConfigureServices(
-        this IMotorHostBuilder hostBuilder,
-        Action<IServiceCollection> configureDelegate
-    )
+    extension(IHostApplicationBuilder builder)
     {
-        hostBuilder.ConfigureServices((_, collection) => configureDelegate(collection));
-        return hostBuilder;
-    }
-
-    public static IMotorHostBuilder ConfigureAppConfiguration(
-        this IMotorHostBuilder hostBuilder,
-        Action<HostBuilderContext, IConfigurationBuilder> configureDelegate
-    )
-    {
-        hostBuilder.ConfigureAppConfiguration(configureDelegate);
-        return hostBuilder;
-    }
-
-    public static IMotorHostBuilder ConfigureSingleOutputService<TInput, TOutput>(
-        this IMotorHostBuilder hostBuilder,
-        string healthCheckConfigSection = "HealthChecks",
-        string messageProcessingHealthCheckName = nameof(MessageProcessingHealthCheck<TInput>),
-        string tooManyTemporaryFailuresHealthCheckName = nameof(TooManyTemporaryFailuresHealthCheck<TInput>)
-    )
-        where TOutput : class
-        where TInput : class
-    {
-        return hostBuilder
-            .ConfigureNoOutputService<TInput>(
+        public IHostApplicationBuilder ConfigureSingleOutputService<TInput, TOutput>(
+            string healthCheckConfigSection = "HealthChecks",
+            string messageProcessingHealthCheckName = nameof(MessageProcessingHealthCheck<TInput>),
+            string tooManyTemporaryFailuresHealthCheckName = nameof(TooManyTemporaryFailuresHealthCheck<TInput>)
+        )
+            where TOutput : class
+            where TInput : class
+        {
+            builder.ConfigureNoOutputService<TInput>(
                 healthCheckConfigSection,
                 messageProcessingHealthCheckName,
                 tooManyTemporaryFailuresHealthCheckName
-            )
-            .ConfigureServices(
-                (_, services) =>
-                {
-                    services.AddTransient<INoOutputService<TInput>, SingleOutputServiceAdapter<TInput, TOutput>>();
-                }
             );
-    }
+            builder.Services.AddTransient<INoOutputService<TInput>, SingleOutputServiceAdapter<TInput, TOutput>>();
 
-    public static IMotorHostBuilder ConfigureMultiOutputService<TInput, TOutput>(
-        this IMotorHostBuilder hostBuilder,
-        string healthCheckConfigSection = "HealthChecks",
-        string messageProcessingHealthCheckName = nameof(MessageProcessingHealthCheck<TInput>),
-        string tooManyTemporaryFailuresHealthCheckName = nameof(TooManyTemporaryFailuresHealthCheck<TInput>)
-    )
-        where TOutput : class
-        where TInput : class
-    {
-        return hostBuilder
-            .ConfigureNoOutputService<TInput>(
+            return builder;
+        }
+
+        public IHostApplicationBuilder ConfigureMultiOutputService<TInput, TOutput>(
+            string healthCheckConfigSection = "HealthChecks",
+            string messageProcessingHealthCheckName = nameof(MessageProcessingHealthCheck<TInput>),
+            string tooManyTemporaryFailuresHealthCheckName = nameof(TooManyTemporaryFailuresHealthCheck<TInput>)
+        )
+            where TOutput : class
+            where TInput : class
+        {
+            builder.ConfigureNoOutputService<TInput>(
                 healthCheckConfigSection,
                 messageProcessingHealthCheckName,
                 tooManyTemporaryFailuresHealthCheckName
-            )
-            .ConfigureServices(
-                (_, services) =>
-                {
-                    services.AddTransient<INoOutputService<TInput>, MultiOutputServiceAdapter<TInput, TOutput>>();
-                }
             );
+            builder.Services.AddTransient<INoOutputService<TInput>, MultiOutputServiceAdapter<TInput, TOutput>>();
+
+            return builder;
+        }
+
+        public IHostApplicationBuilder ConfigureNoOutputService<TInput>(
+            string healthCheckConfigSection = "HealthChecks",
+            string messageProcessingHealthCheckName = nameof(MessageProcessingHealthCheck<TInput>),
+            string tooManyTemporaryFailuresHealthCheckName = nameof(TooManyTemporaryFailuresHealthCheck<TInput>)
+        )
+            where TInput : class
+        {
+            builder
+                .Services.AddHealthChecks()
+                .AddCheck<MessageProcessingHealthCheck<TInput>>(messageProcessingHealthCheckName)
+                .AddCheck<TooManyTemporaryFailuresHealthCheck<TInput>>(tooManyTemporaryFailuresHealthCheckName);
+            builder.Services.AddQueuedGenericService<TInput>();
+            builder.Services.AddTransient<
+                DelegatingMessageHandler<TInput>,
+                TelemetryDelegatingMessageHandler<TInput>
+            >();
+            builder.Services.AddTransient<
+                DelegatingMessageHandler<TInput>,
+                PrometheusDelegatingMessageHandler<TInput>
+            >();
+            builder.Services.Configure<MessageProcessingOptions>(
+                builder.Configuration.GetSection(healthCheckConfigSection).GetSection(messageProcessingHealthCheckName)
+            );
+            builder.Services.AddSingleton<TooManyTemporaryFailuresStatistics<TInput>>();
+            builder.Services.AddTransient<
+                DelegatingMessageHandler<TInput>,
+                TooManyTemporaryFailuresDelegatingMessageHandler<TInput>
+            >();
+            builder.Services.Configure<TooManyTemporaryFailuresOptions>(
+                builder
+                    .Configuration.GetSection(healthCheckConfigSection)
+                    .GetSection(tooManyTemporaryFailuresHealthCheckName)
+            );
+
+            return builder;
+        }
     }
 
-    public static IMotorHostBuilder ConfigureNoOutputService<TInput>(
-        this IMotorHostBuilder hostBuilder,
-        string healthCheckConfigSection = "HealthChecks",
-        string messageProcessingHealthCheckName = nameof(MessageProcessingHealthCheck<TInput>),
-        string tooManyTemporaryFailuresHealthCheckName = nameof(TooManyTemporaryFailuresHealthCheck<TInput>)
-    )
-        where TInput : class
+    extension(IHostBuilder builder)
     {
-        return hostBuilder
-            .AddHealthCheck<MessageProcessingHealthCheck<TInput>>(messageProcessingHealthCheckName)
-            .AddHealthCheck<TooManyTemporaryFailuresHealthCheck<TInput>>(tooManyTemporaryFailuresHealthCheckName)
-            .ConfigureServices(
+        public IHostBuilder ConfigureSingleOutputService<TInput, TOutput>(
+            string healthCheckConfigSection = "HealthChecks",
+            string messageProcessingHealthCheckName = nameof(MessageProcessingHealthCheck<TInput>),
+            string tooManyTemporaryFailuresHealthCheckName = nameof(TooManyTemporaryFailuresHealthCheck<TInput>)
+        )
+            where TOutput : class
+            where TInput : class =>
+            builder
+                .ConfigureNoOutputService<TInput>(
+                    healthCheckConfigSection,
+                    messageProcessingHealthCheckName,
+                    tooManyTemporaryFailuresHealthCheckName
+                )
+                .ConfigureServices(
+                    (_, services) =>
+                    {
+                        services.AddTransient<INoOutputService<TInput>, SingleOutputServiceAdapter<TInput, TOutput>>();
+                    }
+                );
+
+        public IHostBuilder ConfigureMultiOutputService<TInput, TOutput>(
+            string healthCheckConfigSection = "HealthChecks",
+            string messageProcessingHealthCheckName = nameof(MessageProcessingHealthCheck<TInput>),
+            string tooManyTemporaryFailuresHealthCheckName = nameof(TooManyTemporaryFailuresHealthCheck<TInput>)
+        )
+            where TOutput : class
+            where TInput : class =>
+            builder
+                .ConfigureNoOutputService<TInput>(
+                    healthCheckConfigSection,
+                    messageProcessingHealthCheckName,
+                    tooManyTemporaryFailuresHealthCheckName
+                )
+                .ConfigureServices(
+                    (_, services) =>
+                    {
+                        services.AddTransient<INoOutputService<TInput>, MultiOutputServiceAdapter<TInput, TOutput>>();
+                    }
+                );
+
+        public IHostBuilder ConfigureNoOutputService<TInput>(
+            string healthCheckConfigSection = "HealthChecks",
+            string messageProcessingHealthCheckName = nameof(MessageProcessingHealthCheck<TInput>),
+            string tooManyTemporaryFailuresHealthCheckName = nameof(TooManyTemporaryFailuresHealthCheck<TInput>)
+        )
+            where TInput : class =>
+            builder.ConfigureServices(
                 (hostContext, services) =>
                 {
+                    services
+                        .AddHealthChecks()
+                        .AddCheck<MessageProcessingHealthCheck<TInput>>(messageProcessingHealthCheckName)
+                        .AddCheck<TooManyTemporaryFailuresHealthCheck<TInput>>(tooManyTemporaryFailuresHealthCheckName);
                     services.AddQueuedGenericService<TInput>();
                     services.AddTransient<
                         DelegatingMessageHandler<TInput>,

--- a/src/Motor.Extensions.Utilities/LegacyMotorHostExtensions.cs
+++ b/src/Motor.Extensions.Utilities/LegacyMotorHostExtensions.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+using Motor.Extensions.Utilities.Abstractions;
+
+namespace Motor.Extensions.Utilities;
+
+public static class StartupExtensions
+{
+    extension(IHostBuilder builder)
+    {
+        public IHostBuilder UseStartup<T>()
+            where T : IMotorStartup
+        {
+            var startup = Activator.CreateInstance<T>();
+
+            builder.ConfigureWebHost(webHostBuilder =>
+            {
+                webHostBuilder.UseSetting(WebHostDefaults.ApplicationKey, typeof(T).Assembly.GetName().Name);
+                webHostBuilder.Configure(startup.Configure);
+                webHostBuilder.ConfigureServices(startup.ConfigureServices);
+            });
+
+            return builder;
+        }
+
+        [Obsolete("Use IServiceCollection.AddHealthChecks().AddCheck<T>(...) instead")]
+        public IHostBuilder AddHealthCheck<T>(
+            string name,
+            HealthStatus? failureStatus = null,
+            IEnumerable<string>? tags = null,
+            TimeSpan? timeout = null
+        )
+            where T : class, IHealthCheck =>
+            builder.ConfigureServices(
+                (_, services) =>
+                {
+                    services.AddHealthChecks().AddCheck<T>(name, failureStatus, tags, timeout);
+                }
+            );
+    }
+}

--- a/src/Motor.Extensions.Utilities/MotorDefaults.cs
+++ b/src/Motor.Extensions.Utilities/MotorDefaults.cs
@@ -1,0 +1,48 @@
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Motor.Extensions.ContentEncoding.Abstractions;
+using Motor.Extensions.Diagnostics.Logging;
+using Motor.Extensions.Diagnostics.Metrics;
+using Motor.Extensions.Diagnostics.Telemetry;
+using Motor.Extensions.Hosting;
+using Motor.Extensions.Hosting.CloudEvents;
+
+namespace Motor.Extensions.Utilities;
+
+public static class MotorDefaults
+{
+    extension(IHostApplicationBuilder builder)
+    {
+        public void AddApplicationNameService(string applicationName = "ApplicationName", Assembly? assembly = null)
+        {
+            assembly ??= Assembly.GetCallingAssembly();
+
+            builder.Services.Configure<DefaultApplicationNameOptions>(
+                builder.Configuration.GetSection(applicationName)
+            );
+
+            builder.Services.AddTransient<IApplicationNameService>(provider =>
+            {
+                var options = provider.GetRequiredService<IOptions<DefaultApplicationNameOptions>>();
+                return new DefaultApplicationNameService(assembly, options);
+            });
+        }
+
+        public IHostApplicationBuilder AddMotorDefaults(
+            string applicationName = "ApplicationName",
+            string contentEncoding = "ContentEncoding",
+            Assembly? assembly = null
+        )
+        {
+            builder.AddApplicationNameService(applicationName, assembly);
+            builder.Services.Configure<ContentEncodingOptions>(builder.Configuration.GetSection(contentEncoding));
+            builder.ConfigureMotorLogging();
+            builder.ConfigureMotorTelemetry();
+            builder.ConfigurePrometheus();
+
+            return builder;
+        }
+    }
+}

--- a/test/Motor.Extensions.Diagnostics.Telemetry_IntegrationTest/OpenTelemetryTests.cs
+++ b/test/Motor.Extensions.Diagnostics.Telemetry_IntegrationTest/OpenTelemetryTests.cs
@@ -14,7 +14,6 @@ using Motor.Extensions.Hosting.Consumer;
 using Motor.Extensions.Hosting.Publisher;
 using Motor.Extensions.TestUtilities;
 using Motor.Extensions.Utilities;
-using Motor.Extensions.Utilities.Abstractions;
 using OpenTelemetry.Exporter;
 using Serilog;
 using Xunit;
@@ -83,7 +82,7 @@ public class OpenTelemetryTests : IDisposable, IClassFixture<OpenTelemetryCollec
         InMemoryConsumer<string> consumer,
         InMemoryPublisher<string> publisher,
         string? appSettings,
-        params Func<IMotorHostBuilder, IMotorHostBuilder>[] extraConfigurations
+        params Func<IHostBuilder, IHostBuilder>[] extraConfigurations
     )
     {
         var motorHostBuilder = new MotorHostBuilder(new HostBuilder(), false)

--- a/test/Motor.Extensions.Hosting.RabbitMQ_UnitTest/RabbitMQMessageHostBuilderExtensionsTests.cs
+++ b/test/Motor.Extensions.Hosting.RabbitMQ_UnitTest/RabbitMQMessageHostBuilderExtensionsTests.cs
@@ -1,9 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Moq;
 using Motor.Extensions.Conversion.Abstractions;
 using Motor.Extensions.Hosting.Abstractions;
@@ -12,14 +10,13 @@ using Motor.Extensions.Hosting.Consumer;
 using Motor.Extensions.Hosting.Publisher;
 using Motor.Extensions.Hosting.RabbitMQ;
 using Motor.Extensions.Utilities;
-using Motor.Extensions.Utilities.Abstractions;
 using Xunit;
 
 namespace Motor.Extensions.Hosting.RabbitMQ_UnitTest;
 
 public class RabbitMQMessageHostBuilderExtensionsTests
 {
-    private static IMotorHostBuilder GetHostBuilder()
+    private static IHostBuilder GetHostBuilder()
     {
         return MotorHost
             .CreateDefaultBuilder()


### PR DESCRIPTION
- bump language version to 14
- use C# 14 extension member syntax to group extension functions by extension type
- use new collection syntax where applicable
- add examples for usage without MotorHost
- expose opinionated setup extension for logging independent of MotorHost
- expose convenience extension to apply Motor defaults to regular IHostApplicationBuilder