### PR TITLE
fix(KafkaClientExtensions): Fix uppercase characters not being allowed in CloudEvents

### DIFF
--- a/src/Motor.Extensions.Hosting.Kafka/KafkaClientExtensions.cs
+++ b/src/Motor.Extensions.Hosting.Kafka/KafkaClientExtensions.cs
@@ -81,7 +81,10 @@ internal static class KafkaClientExtensions
             {
                 try
                 {
-                    motorCloudEvent.SetAttributeFromString(header.Key, Encoding.UTF8.GetString(headerValue));
+                    motorCloudEvent.SetAttributeFromString(
+                        header.Key.ToLowerInvariant(),
+                        Encoding.UTF8.GetString(headerValue)
+                    );
                 }
                 catch (ArgumentException)
                 {

--- a/test/Motor.Extensions.Hosting.Kafka_IntegrationTest/KafkaExtensionTests.cs
+++ b/test/Motor.Extensions.Hosting.Kafka_IntegrationTest/KafkaExtensionTests.cs
@@ -80,19 +80,20 @@ public class KafkaExtensionTests(ITestOutputHelper output, KafkaFixture fixture)
     public async Task Consume_RawPublishWithKafkaHeader_HeaderValueIsAvailableAsCloudEventAttribute()
     {
         var topic = NewTopic();
-        const string headerKey = "customheader";
+        const string headerKeyOriginal = "CustomHeaderNamE";
+        const string headerKeyConverted = "customheadername";
         const string headerValue = "customHeaderValue";
         await PublishMessage(
             topic,
             "someKey",
             Message,
-            new Headers { { headerKey, Encoding.UTF8.GetBytes(headerValue) } }
+            new Headers { { headerKeyOriginal, Encoding.UTF8.GetBytes(headerValue) } }
         );
         using var consumer = GetConsumer<string>(topic);
         var consumedHeaderValueCompletionSource = new TaskCompletionSource<string?>();
         consumer.ConsumeCallbackAsync = (dataEvent, _) =>
         {
-            consumedHeaderValueCompletionSource.TrySetResult(dataEvent[headerKey] as string);
+            consumedHeaderValueCompletionSource.TrySetResult(dataEvent[headerKeyConverted] as string);
             return Task.FromResult(ProcessedMessageStatus.Success);
         };
 

--- a/test/Motor.Extensions.Hosting.Kafka_UnitTest/KafkaMessageTests.cs
+++ b/test/Motor.Extensions.Hosting.Kafka_UnitTest/KafkaMessageTests.cs
@@ -90,7 +90,7 @@ public class KafkaMessageTests
         var kafkaMessage = publisher.CloudEventToKafkaMessage(inputCloudEvent);
         kafkaMessage.Headers ??= new Headers();
         kafkaMessage.Headers.Add("firstcustomheader", "customvalue"u8.ToArray());
-        kafkaMessage.Headers.Add("secondcustomheader", "customvalue_two"u8.ToArray());
+        kafkaMessage.Headers.Add("SECONDCUSTOMHEADER", "customvalue_two"u8.ToArray());
 
         var outputCloudEvent = consumer.KafkaMessageToCloudEvent(kafkaMessage);
 


### PR DESCRIPTION
We encountered an issue where our Kafka sends events in PascalCase, but the CloudEvents attribute validator (https://github.com/cloudevents/sdk-csharp/blob/main/src/CloudNative.CloudEvents/CloudEventAttribute.cs#L105) only allows alphanumeric lowercase characters, leading to those header names being ignored when converting from Kafka header to CloudEvent attribute.